### PR TITLE
IDE: Add DataGrip

### DIFF
--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.1"
+  "message": "2.1.2"
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,9 @@ html_context.update({
 
 # TODO: Refactor into global configuration.
 linkcheck_ignore = [
+    # HTTPSConnectionPool(host='xxx.microsoft.com', port=443): Read timed out. (read timeout=5)
+    "https://azure.microsoft.com/",
     "https://azuremarketplace.microsoft.com/",
-    "https://github.com/crate/ml-sandbox",
     "https://portal.azure.com/",
     "https://powerbi.microsoft.com",
     "https://www.microsoft.com",

--- a/docs/connect/ide.md
+++ b/docs/connect/ide.md
@@ -6,6 +6,29 @@ Mostly through its PostgreSQL interface, CrateDB supports working with popular
 database IDE (Integrated Development Environment) applications.
 
 
+## DataGrip
+
+```{div}
+:style: "float: right"
+[![](https://blog.jetbrains.com/wp-content/uploads/2019/01/datagrip_icon.svg){w=120px}](https://www.jetbrains.com/datagrip/)
+```
+
+[DataGrip] is a cross-platform database IDE that is tailored to suit the specific needs
+of professional SQL developers.
+
+Connecting DataGrip to CrateDB uses the vanilla PostgreSQL JDBC Driver,
+the blog article [Blog: Use CrateDB With DataGrip] explains how it works.
+
+![image](https://19927462.fs1.hubspotusercontent-na1.net/hub/19927462/hubfs/13-Datagrip.png?width=1536&name=CrateDB-DataGrip.png){h=200px}
+![image](https://www.pgadmin.org/static/COMPILED/assets/img/screenshots/pgadmin4-welcome-light.png){h=200px}
+
+:::{caution}
+Please note while the query console works well, you will notice that many UI
+actions do not work yet. We are tracking corresponding gaps at [Tool: DataGrip],
+and appreciate any contributions to improve the situation.
+:::
+
+
 ## DBeaver
 
 ```{div}
@@ -26,4 +49,6 @@ article [Blog: Use CrateDB With DBeaver] explains how it works.
 
 [Blog: Use CrateDB With DataGrip]: https://cratedb.com/blog/use-cratedb-with-datagrip-an-advanced-database-ide
 [Blog: Use CrateDB With DBeaver]: https://cratedb.com/blog/cratedb-dbeaver
+[DataGrip]: https://www.jetbrains.com/datagrip/
 [DBeaver]: https://dbeaver.io/
+[Tool: DataGrip]: https://github.com/crate/crate/labels/tool%3A%20DataGrip


### PR DESCRIPTION
## About
DataGrip needed to be retracted from GH-33, because it does not work [well] with CrateDB.

## Preview
https://crate-clients-tools--35.org.readthedocs.build/en/35/connect/ide.html

## References
- https://github.com/crate/crate/issues/12101
- https://github.com/crate/crate/discussions/10841
