### PR TITLE
Add item about Kestra to "etl" section

### DIFF
--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -1,3 +1,4 @@
+(bi-tools)=
 (analyze)=
 # Analytics with CrateDB
 

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -122,6 +122,36 @@ all database update operations.
 - [Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]
 
 
+## Kestra
+
+```{div}
+:style: "float: right"
+[![](https://kestra.io/logo.svg){w=180px}](https://kestra.io/)
+```
+
+[Kestra] is an open source workflow automation and orchestration toolkit with a rich
+plugin ecosystem. It enables users to automate and manage complex workflows in a
+streamlined and efficient manner, defining them both declaratively, or imperatively
+using any scripting language like Python, Bash, or JavaScript.
+
+Kestra comes with a user-friendly web-based interface including a live-updating DAG
+view, allowing users to create, modify, and manage scheduled and event-driven flows
+without the need for any coding skills.
+
+Plugins are at the core of Kestra's extensibility. Many plugins are available from
+the Kestra core team, and creating your own is easy. With plugins, you can add new
+functionality to Kestra.
+
+- [Setting up data pipelines with CrateDB and Kestra]
+
+![](https://kestra.io/landing/home/ui-3.png){h=120px}
+![](https://kestra.io/landing/home/ui-4.png){h=120px}
+![](https://kestra.io/landing/features/declarative.svg){h=120px}
+
+```{seealso}
+[CrateDB and Kestra]
+```
+
 
 ## Node-RED
 
@@ -194,6 +224,7 @@ to other systems leaves nothing to be desired.
 [CrateDB and Apache Airflow]: https://crate.io/integrations/cratedb-and-apache-airflow
 [CrateDB and Apache Airflow: Building a data ingestion pipeline]: https://community.crate.io/t/cratedb-and-apache-airflow-building-a-data-ingestion-pipeline/926 
 [CrateDB and Apache Kafka]: https://crate.io/integrations/cratedb-and-kafka
+[CrateDB and Kestra]: https://crate.io/integrations/cratedb-and-kestra
 [CrateDB and Node-RED]: https://crate.io/integrations/cratedb-and-node-red
 [CrateDB and Telegraf]: https://crate.io/integrations/cratedb-and-telegraf
 [Data Ingestion using Kafka and Kafka Connect]: https://crate.io/docs/crate/howtos/en/latest/integrations/kafka-connect.html
@@ -205,8 +236,10 @@ to other systems leaves nothing to be desired.
 [Implementing a data retention policy in CrateDB using Apache Airflow]: https://community.crate.io/t/implementing-a-data-retention-policy-in-cratedb-using-apache-airflow/913 
 [Importing Parquet files into CrateDB using Apache Arrow and SQLAlchemy]: https://community.crate.io/t/importing-parquet-files-into-cratedb-using-apache-arrow-and-sqlalchemy/1161
 [Ingesting MQTT messages into CrateDB using Node-RED]: https://community.crate.io/t/ingesting-mqtt-messages-into-cratedb-using-node-red/803
+[Kestra]: https://kestra.io/
 [Node-RED]: https://nodered.org/
 [pandas]: https://pandas.pydata.org/
+[Setting up data pipelines with CrateDB and Kestra]: https://community.crate.io/t/setting-up-data-pipelines-with-cratedb-and-kestra-io/1400
 [Telegraf]: https://www.influxdata.com/time-series-platform/telegraf/
 [Tutorial: Replicating data to CrateDB with Debezium and Kafka]: https://community.crate.io/t/replicating-data-to-cratedb-with-debezium-and-kafka/1388
 [Updating stock market data automatically with CrateDB and Apache Airflow]: https://community.crate.io/t/updating-stock-market-data-automatically-with-cratedb-and-apache-airflow/1304

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -78,6 +78,35 @@ data integration, and mission-critical applications.
 ```
 
 
+## dbt
+
+```{div}
+:style: "float: right"
+[![](https://www.getdbt.com/ui/img/logos/dbt-logo.svg){w=180px}](https://www.getdbt.com/)
+```
+
+[dbt] is an open source tool for transforming data in data warehouses using Python and
+SQL. It is an SQL-first transformation workflow platform that lets teams quickly and
+collaboratively deploy analytics code following software engineering best practices
+like modularity, portability, CI/CD, and documentation.
+
+> dbt enables data analysts and engineers to transform their data using the same
+> practices that software engineers use to build applications.
+
+With dbt, anyone on your data team can safely contribute to production-grade data pipelines.
+
+The idea is that data engineers make source data available to an environment where
+dbt projects run, for example with [Debezium](#debezium) or with [Airflow](#apache-airflow).
+Afterwards, data analysts can run their dbt projects against this data to produce models
+(tables and views) that can be used with a number of [BI tools](#bi-tools).
+
+- [Using dbt with CrateDB]
+
+![](https://www.getdbt.com/ui/img/products/what-is-dbt-main-image.png){h=120px}
+![](https://www.getdbt.com/ui/img/products/what-is-dbt-deploy.svg){h=120px}
+![](https://www.getdbt.com/ui/img/products/what-is-dbt-eliminate-silos.svg){h=120px}
+
+
 ## Debezium
 
 ```{div}
@@ -168,6 +197,7 @@ to other systems leaves nothing to be desired.
 [CrateDB and Node-RED]: https://crate.io/integrations/cratedb-and-node-red
 [CrateDB and Telegraf]: https://crate.io/integrations/cratedb-and-telegraf
 [Data Ingestion using Kafka and Kafka Connect]: https://crate.io/docs/crate/howtos/en/latest/integrations/kafka-connect.html
+[dbt]: https://www.getdbt.com/
 [Debezium]: https://debezium.io/
 [Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 [Guide to efficient data ingestion to CrateDB with pandas]: https://community.crate.io/t/guide-to-efficient-data-ingestion-to-cratedb-with-pandas/1541
@@ -180,5 +210,6 @@ to other systems leaves nothing to be desired.
 [Telegraf]: https://www.influxdata.com/time-series-platform/telegraf/
 [Tutorial: Replicating data to CrateDB with Debezium and Kafka]: https://community.crate.io/t/replicating-data-to-cratedb-with-debezium-and-kafka/1388
 [Updating stock market data automatically with CrateDB and Apache Airflow]: https://community.crate.io/t/updating-stock-market-data-automatically-with-cratedb-and-apache-airflow/1304
+[Using dbt with CrateDB]: https://community.crate.io/t/using-dbt-with-cratedb/1566
 [Use CrateDB With Telegraf, an Agent for Collecting & Reporting Metrics]: https://crate.io/blog/use-cratedb-with-telegraf-an-agent-for-collecting-reporting-metrics
 [Webinar: How to replicate data from other databases to CrateDB with Debezium and Kafka]: https://crate.io/resources/webinars/lp-wb-debezium-kafka


### PR DESCRIPTION
## About

@marijaselakovic published the article [Setting up data pipelines with CrateDB and Kestra](https://community.crate.io/t/setting-up-data-pipelines-with-cratedb-and-kestra-io/1400) the other day already. Thanks. This patch also adds a corresponding item to the "etl" section, and also links to that article.


## Preview

https://crate-clients-tools--42.org.readthedocs.build/en/42/etl.html#kestra
