### PR TITLE
Add managed service offerings to integration items

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -5,6 +5,7 @@
 - [ ] Add item about Admin UI
 - [ ] Add item about `psycopg3`
 - [ ] Connect: Add more properties, like `schema`
+- [ ] ETL: There is pandas, but not Dask/Coiled
 
 ## Iteration +2
 - [ ] Refer to more artefacts/resources

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -2,8 +2,8 @@
 (analyze)=
 # Analytics with CrateDB
 
-This documentation section enumerates analytics applications and frameworks for
-analyzing data in CrateDB.
+This documentation section enumerates analytics applications and frameworks,
+which can be used for analyzing data in CrateDB.
 
 
 ## Business analytics with Microsoft Power BI

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,12 @@
 from crate.theme.rtd.conf.crate_clients_tools import *
 
+# Disable version chooser.
+html_context.update({
+    "display_version": False,
+    "current_version": None,
+    "versions": [],
+})
+
 # TODO: Refactor into global configuration.
 linkcheck_ignore = [
     "https://portal.azure.com/",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,1 +1,9 @@
 from crate.theme.rtd.conf.crate_clients_tools import *
+
+# TODO: Refactor into global configuration.
+linkcheck_ignore = [
+    "https://portal.azure.com/",
+    "https://azuremarketplace.microsoft.com/",
+]
+
+linkcheck_timeout = 5

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -158,7 +158,8 @@ like modularity, portability, CI/CD, and documentation.
 > dbt enables data analysts and engineers to transform their data using the same
 > practices that software engineers use to build applications.
 
-With dbt, anyone on your data team can safely contribute to production-grade data pipelines.
+With dbt, anyone on your data team can safely contribute to production-grade data
+pipelines.
 
 The idea is that data engineers make source data available to an environment where
 dbt projects run, for example with [Debezium](#debezium) or with [Airflow](#apache-airflow).
@@ -170,6 +171,34 @@ Afterwards, data analysts can run their dbt projects against this data to produc
 ![](https://www.getdbt.com/ui/img/products/what-is-dbt-main-image.png){h=120px}
 ![](https://www.getdbt.com/ui/img/products/what-is-dbt-deploy.svg){h=120px}
 ![](https://www.getdbt.com/ui/img/products/what-is-dbt-eliminate-silos.svg){h=120px}
+
+:::{dropdown} **Managed dbt**
+```{div}
+:style: "float: right"
+[![](https://www.getdbt.com/ui/img/hero-dbt-cloud-features-2x5.png){w=180px}](https://www.getdbt.com/product/dbt-cloud/)
+```
+
+With [dbt Cloud], you can ditch time-consuming setup, and the struggles
+of scaling your data production. dbt Cloud is a full-suite service that is built for
+scale.
+
+- Start building data products quickly using the dbt Cloud IDE with integrated security
+  and governance controls.
+- Schedule, deploy, and monitor your data products using the scalable and reliable dbt
+  Cloud Scheduler.
+- Help your data teams discover and reuse data products using hosted docs or integrations
+  with the powerful Discovery API.
+- Extend your workflow beyond dbt Cloud with 30+ seamless integrations covering a range
+  of use cases across the Modern Data Stack, from observability and data quality to
+  visualization, reverse ETL, and much more.
+- Ship more high-quality data and scale your development like the 1000s of companies that
+  use dbt Cloud. They’ve used its convenient and collaboration-friendly interface to
+  eliminate the bottlenecks that keep growth limited.
+
+```{div}
+:style: "clear: both"
+```
+:::
 
 
 ## Debezium
@@ -303,6 +332,7 @@ to other systems leaves nothing to be desired.
 [CrateDB and Telegraf]: https://crate.io/integrations/cratedb-and-telegraf
 [Data Ingestion using Kafka and Kafka Connect]: https://crate.io/docs/crate/howtos/en/latest/integrations/kafka-connect.html
 [dbt]: https://www.getdbt.com/
+[dbt Cloud]: https://www.getdbt.com/product/dbt-cloud/
 [Debezium]: https://debezium.io/
 [DoubleCloud Managed Service for Apache Kafka]: https://double.cloud/services/managed-kafka/
 [Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -123,10 +123,24 @@ thousands of companies for high-performance data pipelines, streaming analytics,
 data integration, and mission-critical applications. 
 
 - [Data Ingestion using Kafka and Kafka Connect]
+- [Executable stack: Apache Kafka, Apache Flink, and CrateDB]
+- [Tutorial: Replicating data to CrateDB with Debezium and Kafka]
 
 ```{seealso}
 [CrateDB and Apache Kafka]
 ```
+
+:::{dropdown} **Managed Kafka**
+A few companies are specializing in offering managed Kafka services. We can't list
+them all, see the [overview about more managed Kafka offerings].
+
+- [Aiven for Apache Kafka]
+- [Amazon Managed Streaming for Apache Kafka (MSK)]
+- [Apache Kafka on Azure]
+- [Azure Event Hubs for Apache Kafka]
+- [Confluent Cloud]
+- [DoubleCloud Managed Service for Apache Kafka]
+:::
 
 
 ## dbt
@@ -265,17 +279,22 @@ to other systems leaves nothing to be desired.
 [2023 SIGMOD Systems Award]: https://sigmod.org/2023-sigmod-systems-award/
 [Aiven]: https://aiven.io/
 [Aiven for Apache Flink]: https://aiven.io/flink
+[Aiven for Apache Kafka]: https://aiven.io/kafka
+[Amazon Managed Streaming for Apache Kafka (MSK)]: https://aws.amazon.com/msk/
 [Apache Airflow]: https://airflow.apache.org/
 [Apache Flink]: https://flink.apache.org/
 [Apache Kafka]: https://kafka.apache.org/
+[Apache Kafka on Azure]: https://azuremarketplace.microsoft.com/marketplace/consulting-services/canonical.0001-com-ubuntu-managed-kafka
 [Astronomer]: https://www.astronomer.io/
 [Automating recurrent CrateDB queries]: https://community.crate.io/t/automating-recurrent-cratedb-queries/788
 [Automating export of CrateDB data to S3 using Apache Airflow]: https://community.crate.io/t/cratedb-and-apache-airflow-automating-data-export-to-s3/901
 [Automating stock data collection and storage with CrateDB and Apache Airflow]: https://community.crate.io/t/automating-stock-data-collection-and-storage-with-cratedb-and-apache-airflow/990
 [Automating the import of Parquet files with Apache Airflow]: https://community.crate.io/t/automating-the-import-of-parquet-files-with-apache-airflow/1247
+[Azure Event Hubs for Apache Kafka]: https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-kafka-overview
 [Build a data ingestion pipeline using Kafka, Flink, and CrateDB]: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
 [Building a hot and cold storage data retention policy in CrateDB with Apache Airflow]: https://community.crate.io/t/cratedb-and-apache-airflow-building-a-hot-cold-storage-data-retention-policy/934
 [Community Day: Stream processing with Apache Flink and CrateDB]: https://crate.io/blog/cratedb-community-day-2nd-edition-summary-and-highlights
+[Confluent Cloud]: https://www.confluent.io/confluent-cloud/
 [CrateDB and Apache Airflow]: https://crate.io/integrations/cratedb-and-apache-airflow
 [CrateDB and Apache Airflow: Building a data ingestion pipeline]: https://community.crate.io/t/cratedb-and-apache-airflow-building-a-data-ingestion-pipeline/926 
 [CrateDB and Apache Kafka]: https://crate.io/integrations/cratedb-and-kafka
@@ -285,6 +304,7 @@ to other systems leaves nothing to be desired.
 [Data Ingestion using Kafka and Kafka Connect]: https://crate.io/docs/crate/howtos/en/latest/integrations/kafka-connect.html
 [dbt]: https://www.getdbt.com/
 [Debezium]: https://debezium.io/
+[DoubleCloud Managed Service for Apache Kafka]: https://double.cloud/services/managed-kafka/
 [Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 [Flink managed by Confluent]: https://www.datanami.com/2023/05/17/confluents-new-cloud-capabilities-address-data-streaming-hurdles/
 [Guide to efficient data ingestion to CrateDB with pandas]: https://community.crate.io/t/guide-to-efficient-data-ingestion-to-cratedb-with-pandas/1541
@@ -295,6 +315,7 @@ to other systems leaves nothing to be desired.
 [Ingesting MQTT messages into CrateDB using Node-RED]: https://community.crate.io/t/ingesting-mqtt-messages-into-cratedb-using-node-red/803
 [Kestra]: https://kestra.io/
 [Node-RED]: https://nodered.org/
+[Overview about more managed Kafka offerings]: https://keen.io/blog/managed-apache-kafka-vs-diy/
 [pandas]: https://pandas.pydata.org/
 [Setting up data pipelines with CrateDB and Kestra]: https://community.crate.io/t/setting-up-data-pipelines-with-cratedb-and-kestra-io/1400
 [Telegraf]: https://www.influxdata.com/time-series-platform/telegraf/

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -89,15 +89,26 @@ journey. Spend time where it counts.
 ```
 
 [Apache Flink] is a framework and distributed processing engine for stateful
-computations over unbounded and bounded data streams. Flink has been designed
-to run in all common cluster environments, perform computations at in-memory
-speed and at any scale.
+computations over unbounded and bounded data streams, written in Java.
+
+Flink has been designed to run in all common cluster environments, perform
+computations at in-memory speed and at any scale. It received the [2023 SIGMOD
+Systems Award].
+
+> Apache Flink greatly expanded the use of stream data-processing.
 
 - [Build a data ingestion pipeline using Kafka, Flink, and CrateDB]
 - [Community Day: Stream processing with Apache Flink and CrateDB]
 - [Executable stack: Apache Kafka, Apache Flink, and CrateDB]
 
 ![](https://flink.apache.org/img/flink-home-graphic.png){h=200px}
+
+:::{dropdown} **Managed Flink**
+A few companies are specializing in offering managed Flink services.
+
+- [Aiven] offers their managed [Aiven for Apache Flink] solution.
+- [Immerok Cloud]'s offering is being converged into [Flink managed by Confluent].
+:::
 
 
 ## Apache Kafka
@@ -251,6 +262,9 @@ to other systems leaves nothing to be desired.
 ```
 
 
+[2023 SIGMOD Systems Award]: https://sigmod.org/2023-sigmod-systems-award/
+[Aiven]: https://aiven.io/
+[Aiven for Apache Flink]: https://aiven.io/flink
 [Apache Airflow]: https://airflow.apache.org/
 [Apache Flink]: https://flink.apache.org/
 [Apache Kafka]: https://kafka.apache.org/
@@ -272,8 +286,10 @@ to other systems leaves nothing to be desired.
 [dbt]: https://www.getdbt.com/
 [Debezium]: https://debezium.io/
 [Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
+[Flink managed by Confluent]: https://www.datanami.com/2023/05/17/confluents-new-cloud-capabilities-address-data-streaming-hurdles/
 [Guide to efficient data ingestion to CrateDB with pandas]: https://community.crate.io/t/guide-to-efficient-data-ingestion-to-cratedb-with-pandas/1541
 [Guide to efficient data ingestion to CrateDB with pandas and Dask]: https://community.crate.io/t/guide-to-efficient-data-ingestion-to-cratedb-with-pandas-and-dask/1482
+[Immerok Cloud]: https://www.immerok.io/product
 [Implementing a data retention policy in CrateDB using Apache Airflow]: https://community.crate.io/t/implementing-a-data-retention-policy-in-cratedb-using-apache-airflow/913 
 [Importing Parquet files into CrateDB using Apache Arrow and SQLAlchemy]: https://community.crate.io/t/importing-parquet-files-into-cratedb-using-apache-arrow-and-sqlalchemy/1161
 [Ingesting MQTT messages into CrateDB using Node-RED]: https://community.crate.io/t/ingesting-mqtt-messages-into-cratedb-using-node-red/803

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -12,15 +12,29 @@ This section is a work in progress.
 
 - [Automating recurrent CrateDB queries]
 
+(apache-airflow)=
+(airflow)=
+(astronomer)=
+## Apache Airflow / Astronomer
 
-## Apache Airflow
+[Apache Airflow] is an open source software platform to programmatically author,
+schedule, and monitor workflows, written in Python.
+[Astronomer] offers managed Airflow services on the cloud of your choice, in
+order to run Airflow with less overhead.
 
-[Apache Airflow] is a software platform to programmatically author, schedule, and
-monitor workflows, written in Python.
+Airflow has a modular architecture and uses a message queue to orchestrate an
+arbitrary number of workers. Pipelines are defined in Python, allowing for
+dynamic pipeline generation and on-demand, code-driven pipeline invocation.
+
+Pipeline parametrization is using the powerful Jinja templating engine.
+To extend the system, you can define your own operators and extend libraries
+to fit the level of abstraction that suits your environment.
 
 ```{div}
 :style: "float: right"
 [![](https://19927462.fs1.hubspotusercontent-na1.net/hub/19927462/hubfs/Partner%20Logos/392x140/Apache-Airflow-Logo-392x140.png?width=784&height=280&name=Apache-Airflow-Logo-392x140.png){w=180px}](https://airflow.apache.org/)
+
+[![](https://logowik.com/content/uploads/images/astronomer2824.jpg){w=180px}](https://www.astronomer.io/)
 ```
 
 A set of starter tutorials.
@@ -39,6 +53,32 @@ A set of elaborated tutorials, including blueprint implementations.
 ```{seealso}
 [CrateDB and Apache Airflow]
 ```
+
+:::{dropdown} **Managed Airflow**
+
+```{div}
+:style: "float: right"
+[![](https://logowik.com/content/uploads/images/astronomer2824.jpg){w=180px}](https://www.astronomer.io/)
+```
+
+[Astro][Astronomer] is the best managed service in the market for teams on any step of their data
+journey. Spend time where it counts.
+
+- Astro runs on the cloud of your choice. Astro manages Airflow and gives you all the
+  features you need to focus on what really matters – your data. All while connecting
+  securely to any service in your network.
+- Create Airflow environments with a click of a button.
+- Protect production DAGs with easy Airflow upgrades and custom high-availability configs.
+- Get visibility into what’s running with analytics views and easy interfaces for logs
+  and alerts. Across environments.
+- Take down tech-debt and learn how to drive Airflow best practices from the experts
+  behind the project. Get world-class support, fast-tracked bug fixes, and same-day
+  access to new Airflow versions.
+
+```{div}
+:style: "clear: both"
+```
+:::
 
 
 ## Apache Flink
@@ -214,6 +254,7 @@ to other systems leaves nothing to be desired.
 [Apache Airflow]: https://airflow.apache.org/
 [Apache Flink]: https://flink.apache.org/
 [Apache Kafka]: https://kafka.apache.org/
+[Astronomer]: https://www.astronomer.io/
 [Automating recurrent CrateDB queries]: https://community.crate.io/t/automating-recurrent-cratedb-queries/788
 [Automating export of CrateDB data to S3 using Apache Airflow]: https://community.crate.io/t/cratedb-and-apache-airflow-automating-data-export-to-s3/901
 [Automating stock data collection and storage with CrateDB and Apache Airflow]: https://community.crate.io/t/automating-stock-data-collection-and-storage-with-cratedb-and-apache-airflow/990

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -8,10 +8,6 @@ This section is a work in progress.
 ```
 
 
-## General
-
-- [Automating recurrent CrateDB queries]
-
 (apache-airflow)=
 (airflow)=
 (astronomer)=
@@ -264,10 +260,43 @@ using the wide range of elements called "nodes" from the palette that can be
 deployed to its runtime in a single-click.
 
 - [Ingesting MQTT messages into CrateDB using Node-RED]
+- [Automating recurrent CrateDB queries using Node-RED]
 
 ```{seealso}
 [CrateDB and Node-RED]
 ```
+
+:::{dropdown} **Managed Node-RED**
+```{div}
+:style: "float: right"
+[![](https://github.com/crate/crate-clients-tools/assets/453543/200d1a92-1e38-453a-89bf-d8b727451fab){w=180px}](https://flowfuse.com/)
+```
+
+With [FlowFuse], and [FlowFuse Cloud], essentially unmanaged and managed DevOps
+for Node-RED, you can reliably deliver Node-RED applications in a continuous,
+collaborative, and secure manner.
+
+- **Collaborative Development:** FlowFuse adds team collaboration to Node-RED,
+  allowing multiple developers to work together on a single instance. With
+  FlowFuse, developers can easily share projects, collaborate in real-time and
+  streamline workflow for faster development and deployment.
+- **Manage Remote Deployments:** Many organizations deploy Node-RED instances to
+  remote servers or edge devices. FlowFuse automates this process by creating
+  snapshots on Node-RED instances that can be deployed to multiple remote targets.
+  It also allows for rollback in cases where something might not have gone correctly.
+- **Streamline Application Delivery:** FlowFuse simplifies the software development
+  lifecycle of Node-RED applications. You can now set up DevOps delivery pipelines
+  to support development, test and production environments for Node-RED application
+  delivery, see [Introduction to FlowFuse].
+- **Flexible FlowFuse Deployment:** We want to make it easy for you to use FlowFuse,
+  so we offer FlowFuse Cloud, a managed cloud service, or a self-hosted solution.
+  You have the freedom to choose the deployment method that works best for your
+  organization.
+
+```{div}
+:style: "clear: both"
+```
+:::
 
 
 ## pandas
@@ -315,7 +344,7 @@ to other systems leaves nothing to be desired.
 [Apache Kafka]: https://kafka.apache.org/
 [Apache Kafka on Azure]: https://azuremarketplace.microsoft.com/marketplace/consulting-services/canonical.0001-com-ubuntu-managed-kafka
 [Astronomer]: https://www.astronomer.io/
-[Automating recurrent CrateDB queries]: https://community.crate.io/t/automating-recurrent-cratedb-queries/788
+[Automating recurrent CrateDB queries using Node-RED]: https://community.crate.io/t/automating-recurrent-cratedb-queries/788
 [Automating export of CrateDB data to S3 using Apache Airflow]: https://community.crate.io/t/cratedb-and-apache-airflow-automating-data-export-to-s3/901
 [Automating stock data collection and storage with CrateDB and Apache Airflow]: https://community.crate.io/t/automating-stock-data-collection-and-storage-with-cratedb-and-apache-airflow/990
 [Automating the import of Parquet files with Apache Airflow]: https://community.crate.io/t/automating-the-import-of-parquet-files-with-apache-airflow/1247
@@ -337,12 +366,15 @@ to other systems leaves nothing to be desired.
 [DoubleCloud Managed Service for Apache Kafka]: https://double.cloud/services/managed-kafka/
 [Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
 [Flink managed by Confluent]: https://www.datanami.com/2023/05/17/confluents-new-cloud-capabilities-address-data-streaming-hurdles/
+[FlowFuse]: https://flowfuse.com/
+[FlowFuse Cloud]: https://app.flowforge.com/
 [Guide to efficient data ingestion to CrateDB with pandas]: https://community.crate.io/t/guide-to-efficient-data-ingestion-to-cratedb-with-pandas/1541
 [Guide to efficient data ingestion to CrateDB with pandas and Dask]: https://community.crate.io/t/guide-to-efficient-data-ingestion-to-cratedb-with-pandas-and-dask/1482
 [Immerok Cloud]: https://www.immerok.io/product
 [Implementing a data retention policy in CrateDB using Apache Airflow]: https://community.crate.io/t/implementing-a-data-retention-policy-in-cratedb-using-apache-airflow/913 
 [Importing Parquet files into CrateDB using Apache Arrow and SQLAlchemy]: https://community.crate.io/t/importing-parquet-files-into-cratedb-using-apache-arrow-and-sqlalchemy/1161
 [Ingesting MQTT messages into CrateDB using Node-RED]: https://community.crate.io/t/ingesting-mqtt-messages-into-cratedb-using-node-red/803
+[Introduction to FlowFuse]: https://flowfuse.com/webinars/2023/introduction-to-flowforge/
 [Kestra]: https://kestra.io/
 [Node-RED]: https://nodered.org/
 [Overview about more managed Kafka offerings]: https://keen.io/blog/managed-apache-kafka-vs-diy/

--- a/docs/etl.md
+++ b/docs/etl.md
@@ -3,10 +3,6 @@
 
 Use ETL applications and frameworks for transferring data in and out of CrateDB.
 
-```{note}
-This section is a work in progress.
-```
-
 
 (apache-airflow)=
 (airflow)=

--- a/docs/visualize.md
+++ b/docs/visualize.md
@@ -2,15 +2,23 @@
 # Visualize data in CrateDB
 
 
-## Apache Superset
+(apache-superset)=
+(preset)=
+(superset)=
+## Apache Superset / Preset
 
 ```{div}
 :style: "float: right"
 [![](https://crate.io/hs-fs/hubfs/Apache-Superset-Logo-392x140@2x.png?width=604&height=216&name=Apache-Superset-Logo-392x140@2x.png){w=180px}](https://superset.apache.org/)
+
+[![](https://github.com/crate/crate-clients-tools/assets/453543/9d07da87-8aff-4569-bf2a-0a16bf89f4bc){w=180px}](https://preset.io/)
 ```
 
 [Apache Superset] is an open-source modern data exploration and visualization
 platform, written in Python.
+
+[Preset] offers a managed, elevated, and enterprise-grade SaaS for open-source
+Apache Superset.
 
 - [Introduction to Time-Series Visualization in CrateDB and Superset]
 - [Use CrateDB and Apache Superset for Open Source Data Warehousing and Visualization]
@@ -22,6 +30,29 @@ platform, written in Python.
 ```{seealso}
 [CrateDB and Superset]
 ```
+
+:::{dropdown} **Managed Superset**
+```{div}
+:style: "float: right"
+[![](https://github.com/crate/crate-clients-tools/assets/453543/9d07da87-8aff-4569-bf2a-0a16bf89f4bc){w=180px}](https://preset.io/)
+```
+
+[Preset Cloud] is a fully-managed, open-source BI for the modern data stack,
+based on Apache Superset.
+
+- **Hassle-free setup:** There is no need to install or maintain software with Preset.
+  Get the latest version of Superset in a secure, reliable, and scalable SaaS experience.
+- **Up-to-date Superset, always:** Access all the latest features of Superset
+  released and thoroughly tested every two weeks.
+- **One-click to deploy multiple workspaces:** Give each team in your organization
+  a separate Superset workspace to protect sensitive data.
+- **Control user roles and access:** Easily assign roles and fine-tune data access
+  using RBAC and row-level security (RLS).
+
+```{div}
+:style: "clear: both"
+```
+:::
 
 
 ## Cluvio
@@ -138,6 +169,8 @@ Metabase <integrate/metabase>
 [Introduction to Time Series Visualization in CrateDB and Explo]: https://crate.io/blog/introduction-to-time-series-visualization-in-cratedb-and-explo
 [Introduction to Time-Series Visualization in CrateDB and Superset]: https://community.crate.io/t/introduction-to-time-series-visualization-in-cratedb-and-superset/1041
 [Metabase]: https://www.metabase.com/
+[Preset]: https://preset.io/
+[Preset Cloud]: https://preset.io/product/
 [Real-time data analytics with Metabase and CrateDB]: https://www.metabase.com/community_posts/real-time-data-analytics-with-metabase-and-cratedb
 [Set up an Apache Superset development sandbox with CrateDB]: https://community.crate.io/t/set-up-an-apache-superset-development-sandbox-with-cratedb/1163
 [Use CrateDB and Apache Superset for Open Source Data Warehousing and Visualization]: https://crate.io/blog/use-cratedb-and-apache-superset-for-open-source-data-warehousing-and-visualization

--- a/docs/visualize.md
+++ b/docs/visualize.md
@@ -151,7 +151,7 @@ Get Grafana fully managed with [Grafana Cloud].
 
 ```{div}
 :style: "float: right"
-[![](https://www.metabase.com/images/logo.svg){w=180px}](https://www.metabase.com/)
+[![](https://www.metabase.com/images/logo.svg){w=180px}](https://www.metabase.com/cloud/)
 ```
 
 [Metabase] is the ultimate data analysis and visualization tool that unlocks the full
@@ -170,6 +170,29 @@ data on their own.
 ```{seealso}
 [CrateDB and Metabase]
 ```
+
+:::{dropdown} **Managed Metabase**
+```{div}
+:style: "float: right"
+[![](https://www.metabase.com/images/logo.svg){w=180px}](https://www.metabase.com/)
+```
+
+With [Metabase Cloud], you will get a fast, reliable, and secure deployment
+with none of the work or hidden costs that come with self-hosting.
+
+- **Save the time** needed for setup and maintenance of the platform, focusing only on the insights we can get from our data.
+- **Trustworthy, production-grade deployment** by people who do this stuff for a living.
+  With the infrastructure, specialists, and thousands of Metabases in our cloud, we've put a lot of thought and resources into optimizing hosting.
+- **Upgrades:** Automatically upgrade to the current version, so you're always getting the latest and greatest of Metabase.
+- **Backups:** The way they should be: there when you need them, out of sight and out of mind when you don't.
+- **SMTP server:** Even your alerts and dashboard subscriptions covered with a preconfigured and managed SMTP server.
+
+
+```{div}
+:style: "clear: both"
+```
+:::
+
 
 
 ```{toctree}
@@ -194,6 +217,7 @@ Metabase <integrate/metabase>
 [Introduction to Time Series Visualization in CrateDB and Explo]: https://crate.io/blog/introduction-to-time-series-visualization-in-cratedb-and-explo
 [Introduction to Time-Series Visualization in CrateDB and Superset]: https://community.crate.io/t/introduction-to-time-series-visualization-in-cratedb-and-superset/1041
 [Metabase]: https://www.metabase.com/
+[Metabase Cloud]: https://www.metabase.com/cloud/
 [Preset]: https://preset.io/
 [Preset Cloud]: https://preset.io/product/
 [Real-time data analytics with Metabase and CrateDB]: https://www.metabase.com/community_posts/real-time-data-analytics-with-metabase-and-cratedb

--- a/docs/visualize.md
+++ b/docs/visualize.md
@@ -1,6 +1,9 @@
 (visualize)=
 # Visualize data in CrateDB
 
+Use dashboard and other data visualization applications and toolkits for
+visualizing data stored inside CrateDB.
+
 
 (apache-superset)=
 (preset)=

--- a/docs/visualize.md
+++ b/docs/visualize.md
@@ -106,9 +106,12 @@ run white-labeled data portals.
 [![](https://crate.io/hs-fs/hubfs/Imported_Blog_Media/grafana-logo-1-520x126.png?width=1040&height=252&name=grafana-logo-1-520x126.png){w=180px}](https://grafana.com/grafana/)
 ```
 
-[Grafana] is the leading open-source metrics visualization tool that helps you
+[Grafana OSS] is the leading open-source metrics visualization tool that helps you
 build real-time dashboards, graphs, and many other sorts of data visualizations.
-It complements CrateDB in monitoring large volumes of machine data in real-time.
+[Grafana Cloud] is a fully-managed service offered by [Grafana Labs].
+
+Grafana complements CrateDB in monitoring and visualizing large volumes of machine
+data in real-time.
 
 Connecting to a CrateDB cluster will use the Grafana PostgreSQL data source adapter.
 The following tutorials outline how to configure Grafana to connect to CrateDB, and
@@ -122,6 +125,26 @@ how to run a database query.
 ```{seealso}
 [CrateDB and Grafana]
 ```
+
+:::{dropdown} **Managed Grafana**
+```{div}
+:style: "float: right"
+[![](https://crate.io/hs-fs/hubfs/Imported_Blog_Media/grafana-logo-1-520x126.png?width=1040&height=252&name=grafana-logo-1-520x126.png){w=180px}](https://grafana.com/grafana/)
+```
+
+Get Grafana fully managed with [Grafana Cloud].
+
+- Offered as a fully managed service, Grafana Cloud is the fastest way to adopt
+  Grafana and includes a scalable, managed backend for metrics, logs, and traces.
+- Managed and administered by Grafana Labs with free and paid options for
+  individuals, teams, and large enterprises.
+- Includes a robust free tier with access to 10k metrics, 50GB logs, 50GB traces,
+  50GB profiles, and 500VUh of k6 testing for 3 users.
+
+```{div}
+:style: "clear: both"
+```
+:::
 
 
 ## Metabase
@@ -165,7 +188,9 @@ Metabase <integrate/metabase>
 [Data Analysis with Cluvio and CrateDB]: https://community.crate.io/t/data-analysis-with-cluvio-and-cratedb/1571
 [Explo]: https://www.explo.co/
 [Explo Explore]: https://www.explo.co/products/explore
-[Grafana]: https://grafana.com/grafana/
+[Grafana Cloud]: https://grafana.com/grafana/
+[Grafana Labs]: https://grafana.com/about/team/
+[Grafana OSS]: https://grafana.com/oss/grafana/
 [Introduction to Time Series Visualization in CrateDB and Explo]: https://crate.io/blog/introduction-to-time-series-visualization-in-cratedb-and-explo
 [Introduction to Time-Series Visualization in CrateDB and Superset]: https://community.crate.io/t/introduction-to-time-series-visualization-in-cratedb-and-superset/1041
 [Metabase]: https://www.metabase.com/


### PR DESCRIPTION
## About

As suggested by @proddata, this adds managed service offerings to corresponding integration items. It does not obstruct the visual appearance too much, by using [sphinx{design} Dropdowns](https://sphinx-design.readthedocs.io/en/latest/dropdowns.html) for the new content.

Let me know if you think I missed some important items to expand, or if you can think of any details which should be added to the new collapsed dropdown sections in one way or another.

## Preview

- https://crate-clients-tools--43.org.readthedocs.build/en/43/etl.html
- https://crate-clients-tools--43.org.readthedocs.build/en/43/visualize.html
