### PR TITLE
This and that: Naming things, Ruby driver/adapter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ html_context.update({
 linkcheck_ignore = [
     "https://portal.azure.com/",
     "https://azuremarketplace.microsoft.com/",
+    "https://github.com/crate/ml-sandbox",
 ]
 
 linkcheck_timeout = 5

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -215,13 +215,14 @@ features of its type system, and to ignore the `ROLLBACK` statement.
 :::
 
 :::{sd-row}
-```{sd-item} Node.js, JavaScript, TypeScript
+```{sd-item} Node.js
 ```
 ```{sd-item}
 [node-postgres](https://node-postgres.com/)
 ```
 ```{sd-item}
-A collection of Node.js modules for interfacing with a PostgreSQL database. [^node-postgres]
+A collection of Node.js modules for interfacing with a PostgreSQL database
+using JavaScript or TypeScript. [^node-postgres]
 ```
 ```{sd-item}
 {tags-primary}`PG`
@@ -394,10 +395,11 @@ Java
 
 :::{sd-row}
 ```{sd-item}
-Node.js, JavaScript, TypeScript
+Node.js
 ```
 ```{sd-item}
-[Connect to CrateDB from Node.js using `node-postgres` or `node-crate`](#javascript)
+[Connect to CrateDB from Node.js/JavaScript/TypeScript using `node-postgres`
+or `node-crate`](#javascript)
 ```
 :::
 

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -260,7 +260,7 @@ For connecting to CrateDB from PHP, using DBAL and Doctrine.
 ```{sd-item} Python
 ```
 ```{sd-item}
-[CrateDB driver](https://crate.io/docs/python/)
+[CrateDB Python driver](https://crate.io/docs/python/)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python. [^blob-support].
@@ -309,6 +309,34 @@ For connecting to CrateDB from Python. [^asyncio-support]
 ```
 ```{sd-item}
 {tags-primary}`PG`
+```
+:::
+
+:::{sd-row}
+```{sd-item} Ruby
+```
+```{sd-item}
+[CrateDB Ruby driver](https://github.com/crate/crate_ruby)
+```
+```{sd-item}
+A Ruby client library for CrateDB.
+```
+```{sd-item}
+{tags-primary}`HTTP`
+```
+:::
+
+:::{sd-row}
+```{sd-item} Ruby
+```
+```{sd-item}
+[CrateDB ActiveRecord adapter](https://github.com/crate/activerecord-crate-adapter)
+```
+```{sd-item}
+Ruby on Rails ActiveRecord adapter for CrateDB.
+```
+```{sd-item}
+{tags-primary}`HTTP`
 ```
 :::
 

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -232,7 +232,7 @@ A collection of Node.js modules for interfacing with a PostgreSQL database. [^no
 ```{sd-item} PHP
 ```
 ```{sd-item}
-[PHP PDO driver](https://crate.io/docs/pdo/)
+[CrateDB PDO driver](https://crate.io/docs/pdo/)
 ```
 ```{sd-item}
 For connecting to CrateDB from PHP.
@@ -246,7 +246,7 @@ For connecting to CrateDB from PHP.
 ```{sd-item} PHP
 ```
 ```{sd-item}
-[PHP DBAL adapter](https://crate.io/docs/dbal/)
+[CrateDB DBAL adapter](https://crate.io/docs/dbal/)
 ```
 ```{sd-item}
 For connecting to CrateDB from PHP, using DBAL and Doctrine.
@@ -260,7 +260,7 @@ For connecting to CrateDB from PHP, using DBAL and Doctrine.
 ```{sd-item} Python
 ```
 ```{sd-item}
-[DB-API driver](https://crate.io/docs/python/)
+[CrateDB driver](https://crate.io/docs/python/)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python. [^blob-support].

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -215,7 +215,7 @@ features of its type system, and to ignore the `ROLLBACK` statement.
 :::
 
 :::{sd-row}
-```{sd-item} JavaScript, TypeScript
+```{sd-item} Node.js, JavaScript, TypeScript
 ```
 ```{sd-item}
 [node-postgres](https://node-postgres.com/)
@@ -366,7 +366,7 @@ Java
 
 :::{sd-row}
 ```{sd-item}
-JavaScript, TypeScript
+Node.js, JavaScript, TypeScript
 ```
 ```{sd-item}
 [Connect to CrateDB from Node.js using `node-postgres` or `node-crate`](#javascript)

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,11 +45,11 @@ based terminal programs.
 :::
 
 
-:::{grid-item-card} {material-outlined}`link;2em` Library
+:::{grid-item-card} {material-outlined}`link;2em` Driver
 :link: connect
 :link-type: ref
 
-Learn how to configure your favorite client library to connect to a
+Learn how to configure your favorite client driver library to connect to a
 CrateDB cluster.
 :::
 

--- a/docs/integrate/analyze.md
+++ b/docs/integrate/analyze.md
@@ -80,9 +80,8 @@ More resources:
 
 ## Machine Learning and CrateDB
 
-Using pandas, NumPy, Matplotlib, Merlion, and MLFlow, to analyze timeseries anomalies.
-
-- [Running Time Series Models in Production using CrateDB]
+- Using pandas, NumPy, Matplotlib, Merlion, and MLFlow, to analyze timeseries anomalies:
+  [Running Time Series Models in Production using CrateDB]
 
 
 [Automating financial data collection and storage in CrateDB with Python and pandas 2.0.0]: https://community.crate.io/t/automating-financial-data-collection-and-storage-in-cratedb-with-python-and-pandas-2-0-0/916


### PR DESCRIPTION
## About

- Naming things: Use "Driver" instead of "Library"
- Naming things: Add Node.js
- Naming things: Use "CrateDB xxx driver" to designate its origin
- Add Ruby driver and ActiveRecord adapter
- Fix build: ML sandbox repository got depublished
