### PR TITLE
Connect: Re-add `node-crate` library. It is maintained.

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -230,6 +230,20 @@ using JavaScript or TypeScript. [^node-postgres]
 :::
 
 :::{sd-row}
+```{sd-item} Node.js
+```
+```{sd-item}
+[node-crate](https://www.npmjs.com/package/node-crate)
+```
+```{sd-item}
+A JavaScript library connecting to the CrateDB HTTP API.
+```
+```{sd-item}
+{tags-primary}`HTTP`
+```
+:::
+
+:::{sd-row}
 ```{sd-item} PHP
 ```
 ```{sd-item}

--- a/docs/integrate/etl.md
+++ b/docs/integrate/etl.md
@@ -379,7 +379,7 @@ to other systems leaves nothing to be desired.
 [Flink managed by Confluent]: https://www.datanami.com/2023/05/17/confluents-new-cloud-capabilities-address-data-streaming-hurdles/
 [FlowFuse]: https://flowfuse.com/
 [FlowFuse Cloud]: https://app.flowforge.com/
-[Immerok Cloud]: https://www.immerok.io/product
+[Immerok Cloud]: https://web.archive.org/web/20230602085618/https://www.immerok.io/product
 [Implementing a data retention policy in CrateDB using Apache Airflow]: https://community.crate.io/t/implementing-a-data-retention-policy-in-cratedb-using-apache-airflow/913 
 [Ingesting MQTT messages into CrateDB using Node-RED]: https://community.crate.io/t/ingesting-mqtt-messages-into-cratedb-using-node-red/803
 [Introduction to FlowFuse]: https://flowfuse.com/webinars/2023/introduction-to-flowforge/


### PR DESCRIPTION
At GH-56, we reported that the [node-crate](https://www.npmjs.com/package/node-crate) library got lost on the recent refactoring. This patch brings it back to the contemporary section about [Database Drivers](https://cratedb.com/docs/crate/clients-tools/en/latest/connect/#client-libraries).
