### PR TITLE
Fix broken links after adjusting folder layout at `cratedb-examples`

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -475,7 +475,7 @@ Framework**
 Java
 ```
 ```{sd-item}
-[Use CrateDB with Apache Flink and Apache Kafka](https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink)
+[Use CrateDB with Apache Flink and Apache Kafka](https://github.com/crate/cratedb-examples/tree/main/application/apache-kafka-flink)
 ```
 :::
 

--- a/docs/integrate/etl.md
+++ b/docs/integrate/etl.md
@@ -375,7 +375,7 @@ to other systems leaves nothing to be desired.
 [Debezium]: https://debezium.io/
 [DoubleCloud Managed Service for Apache Kafka]: https://double.cloud/services/managed-kafka/
 [Examples about working with CrateDB and Meltano]: https://github.com/crate/cratedb-examples/tree/amo/meltano/framework/singer-meltano
-[Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink
+[Executable stack: Apache Kafka, Apache Flink, and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/apache-kafka-flink
 [Flink managed by Confluent]: https://www.datanami.com/2023/05/17/confluents-new-cloud-capabilities-address-data-streaming-hurdles/
 [FlowFuse]: https://flowfuse.com/
 [FlowFuse Cloud]: https://app.flowforge.com/

--- a/docs/integrate/visualize.md
+++ b/docs/integrate/visualize.md
@@ -121,7 +121,7 @@ domain-specific Dash components and applications.
   interpolation of missing data, common table expressions, moving averages, JOINs, and
   the handling of JSON data.
 
-  [![Open on GitHub](https://img.shields.io/badge/Open%20on-GitHub-lightgray?logo=GitHub)](https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/explore/timeseries-queries-and-visualization.ipynb) [![Open in Collab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/explore/timeseries-queries-and-visualization.ipynb)
+  [![Open on GitHub](https://img.shields.io/badge/Open%20on-GitHub-lightgray?logo=GitHub)](https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb) [![Open in Collab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb)
 
 - [Explore Dash Examples]
 
@@ -350,7 +350,7 @@ Based on Plotly, [Dash] is a low-code framework for rapidly building data apps i
   interpolation of missing data, common table expressions, moving averages, JOINs, and
   the handling of JSON data.
 
-  [![Open on GitHub](https://img.shields.io/badge/Open%20on-GitHub-lightgray?logo=GitHub)](https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/explore/timeseries-queries-and-visualization.ipynb) [![Open in Collab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/explore/timeseries-queries-and-visualization.ipynb)
+  [![Open on GitHub](https://img.shields.io/badge/Open%20on-GitHub-lightgray?logo=GitHub)](https://github.com/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb) [![Open in Collab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/crate/cratedb-examples/blob/main/topic/timeseries/timeseries-queries-and-visualization.ipynb)
 
 - [Explore Dash Examples]
 
@@ -399,4 +399,4 @@ Based on Plotly, [Dash] is a low-code framework for rapidly building data apps i
 [Use CrateDB and Apache Superset for Open Source Data Warehousing and Visualization (Blog)]: https://crate.io/blog/use-cratedb-and-apache-superset-for-open-source-data-warehousing-and-visualization
 [Using Grafana with CrateDB Cloud]: #integrations-grafana
 [Using Metabase with CrateDB Cloud]: #integrations-metabase
-[Verify Apache Superset with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/framework/apache-superset
+[Verify Apache Superset with CrateDB]: https://github.com/crate/cratedb-examples/tree/main/application/apache-superset


### PR DESCRIPTION
## About

The directory layout at `cratedb-examples` has been improved. This patch compensates for that.

## References

- https://github.com/crate/cratedb-examples/pull/271
- https://github.com/crate/cratedb-examples/pull/278
