### PR TITLE
Status: Add a dedicated "Build Status" page

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -128,7 +128,7 @@ We recommend to use those drivers and adapters for the corresponding languages a
 ### Overview
 
 ::::{sd-table}
-:widths: 1 3 5 1 2
+:widths: 2 3 5 2
 :row-class: top-border
 
 :::{sd-row}
@@ -138,9 +138,7 @@ We recommend to use those drivers and adapters for the corresponding languages a
 ```
 ```{sd-item} **Description**
 ```
-```{sd-item} **Proto**
-```
-```{sd-item} **Version/Status**
+```{sd-item} **Protocol**
 ```
 :::
 
@@ -166,6 +164,8 @@ For connecting to CrateDB from any environment that supports it.
 ```
 ```{sd-item}
 [Npgsql](https://www.npgsql.org/)
+
+[![](https://img.shields.io/github/v/tag/npgsql/npgsql?label=latest)](https://github.com/npgsql/npgsql)
 ```
 ```{sd-item}
 An open source ADO.NET Data Provider for PostgreSQL, for program written in C#,
@@ -174,10 +174,6 @@ Visual Basic, and F#.
 ```{sd-item}
 {tags-primary}`PG`
 ```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/npgsql/npgsql?label=latest)](https://github.com/npgsql/npgsql)
-[![](https://img.shields.io/github/actions/workflow/status/npgsql/npgsql/build.yml)](https://github.com/npgsql/npgsql/actions/workflows/build.yml)
-```
 :::
 
 :::{sd-row}
@@ -185,6 +181,8 @@ Visual Basic, and F#.
 ```
 ```{sd-item}
 [CrateDB Npgsql fork](https://crate.io/docs/npgsql/)
+
+[![](https://img.shields.io/github/v/tag/crate/npgsql?label=latest)](https://github.com/crate/npgsql)
 ```
 ```{sd-item}
 This fork of the official driver was needed prior to CrateDB 4.2.
@@ -199,16 +197,14 @@ This fork of the official driver was needed prior to CrateDB 4.2.
 ```
 ```{sd-item}
 [pgx](https://github.com/jackc/pgx)
+
+[![](https://img.shields.io/github/v/tag/jackc/pgx?label=latest)](https://github.com/jackc/pgx)
 ```
 ```{sd-item}
 A pure Go driver and toolkit for PostgreSQL.
 ```
 ```{sd-item}
 {tags-primary}`PG`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/jackc/pgx?label=latest)](https://github.com/jackc/pgx)
-[![](https://img.shields.io/github/actions/workflow/status/jackc/pgx/ci.yml)](https://github.com/jackc/pgx/actions/workflows/ci.yml)
 ```
 :::
 
@@ -217,6 +213,8 @@ A pure Go driver and toolkit for PostgreSQL.
 ```
 ```{sd-item}
 [PostgreSQL JDBC](https://jdbc.postgresql.org/)
+
+[![](https://img.shields.io/github/v/tag/pgjdbc/pgjdbc?label=latest)](https://github.com/pgjdbc/pgjdbc)
 ```
 ```{sd-item}
 The official PostgreSQL JDBC Driver.
@@ -225,21 +223,21 @@ For connecting to CrateDB from any environment that supports it.
 ```{sd-item}
 {tags-primary}`PG`
 ```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/pgjdbc/pgjdbc?label=latest)](https://github.com/pgjdbc/pgjdbc)
-[![](https://img.shields.io/github/actions/workflow/status/pgjdbc/pgjdbc/main.yml)](https://github.com/pgjdbc/pgjdbc/actions/workflows/main.yml)
-```
 :::
+
 
 :::{sd-row}
 ```{sd-item} Java
 ```
 ```{sd-item}
 [CrateDB PgJDBC fork](https://crate.io/docs/jdbc/)
+
+[![](https://img.shields.io/maven-central/v/io.crate/crate-jdbc?label=latest)](https://github.com/crate/pgjdbc)
 ```
 ```{sd-item}
-For connecting to CrateDB within special scenarios, in order to leverage more
-features of its type system, and to ignore the `ROLLBACK` statement.
+For connecting to CrateDB with specialized type system support and
+other tweaks. Ignores the `ROLLBACK` statement and the `hstore` and
+`jsonb` extensions.
 ```
 ```{sd-item}
 {tags-primary}`PG`
@@ -251,6 +249,8 @@ features of its type system, and to ignore the `ROLLBACK` statement.
 ```
 ```{sd-item}
 [node-postgres](https://node-postgres.com/)
+
+[![](https://img.shields.io/npm/v/pg?label=latest&color=blue)](https://github.com/brianc/node-postgres)
 ```
 ```{sd-item}
 A collection of Node.js modules for interfacing with a PostgreSQL database
@@ -259,10 +259,6 @@ using JavaScript or TypeScript. [^node-postgres]
 ```{sd-item}
 {tags-primary}`PG`
 ```
-```{sd-item}
-[![](https://img.shields.io/npm/v/node-postgres?label=latest&color=blue)](https://github.com/brianc/node-postgres)
-[![](https://img.shields.io/github/actions/workflow/status/brianc/node-postgres/ci.yml)](https://github.com/brianc/node-postgres/actions/workflows/ci.yml)
-```
 :::
 
 :::{sd-row}
@@ -270,15 +266,14 @@ using JavaScript or TypeScript. [^node-postgres]
 ```
 ```{sd-item}
 [node-crate](https://www.npmjs.com/package/node-crate)
+
+[![](https://img.shields.io/github/v/tag/megastef/node-crate?label=latest)](https://github.com/megastef/node-crate)
 ```
 ```{sd-item}
 A JavaScript library connecting to the CrateDB HTTP API.
 ```
 ```{sd-item}
 {tags-primary}`HTTP`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/megastef/node-crate?label=latest)](https://github.com/megastef/node-crate)
 ```
 :::
 
@@ -287,16 +282,14 @@ A JavaScript library connecting to the CrateDB HTTP API.
 ```
 ```{sd-item}
 [CrateDB PDO driver](https://crate.io/docs/pdo/)
+
+[![](https://img.shields.io/github/v/tag/crate/crate-pdo?label=latest)](https://github.com/crate/crate-pdo)
 ```
 ```{sd-item}
 For connecting to CrateDB from PHP.
 ```
 ```{sd-item}
 {tags-success}`HTTP`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/crate/crate-pdo?label=latest)](https://github.com/crate/crate-pdo)
-[![](https://img.shields.io/github/actions/workflow/status/crate/crate-pdo/tests.yml)](https://github.com/crate/crate-pdo/actions/workflows/tests.yml)
 ```
 :::
 
@@ -305,16 +298,14 @@ For connecting to CrateDB from PHP.
 ```
 ```{sd-item}
 [CrateDB DBAL adapter](https://crate.io/docs/dbal/)
+
+[![](https://img.shields.io/github/v/tag/crate/crate-dbal?label=latest)](https://github.com/crate/crate-dbal)
 ```
 ```{sd-item}
 For connecting to CrateDB from PHP, using DBAL and Doctrine.
 ```
 ```{sd-item}
 {tags-success}`HTTP`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/crate/crate-dbal?label=latest)](https://github.com/crate/crate-dbal)
-[![](https://img.shields.io/github/actions/workflow/status/crate/crate-dbal/tests.yml)](https://github.com/crate/crate-dbal/actions/workflows/tests.yml)
 ```
 :::
 
@@ -323,16 +314,14 @@ For connecting to CrateDB from PHP, using DBAL and Doctrine.
 ```
 ```{sd-item}
 [CrateDB Python driver](https://crate.io/docs/python/)
+
+[![](https://img.shields.io/github/v/tag/crate/crate-python?label=latest)](https://github.com/crate/crate-python)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python. [^blob-support].
 ```
 ```{sd-item}
 {tags-success}`HTTP`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/crate/crate-python?label=latest)](https://github.com/crate/crate-python)
-[![](https://img.shields.io/github/actions/workflow/status/crate/crate-python/tests.yml)](https://github.com/crate/crate-python/actions/workflows/tests.yml)
 ```
 :::
 
@@ -341,16 +330,14 @@ For connecting to CrateDB from Python. [^blob-support].
 ```
 ```{sd-item}
 [SQLAlchemy dialect](https://crate.io/docs/python/en/latest/sqlalchemy.html)
+
+[![](https://img.shields.io/github/v/tag/crate/crate-python?label=latest)](https://github.com/crate/crate-python)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python, using SQLAlchemy.
 ```
 ```{sd-item}
 {tags-success}`HTTP`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/crate/crate-python?label=latest)](https://github.com/crate/crate-python)
-[![](https://img.shields.io/github/actions/workflow/status/crate/crate-python/tests.yml)](https://github.com/crate/crate-python/actions/workflows/tests.yml)
 ```
 :::
 
@@ -359,16 +346,14 @@ For connecting to CrateDB from Python, using SQLAlchemy.
 ```
 ```{sd-item}
 [asyncpg](https://github.com/MagicStack/asyncpg)
+
+[![](https://img.shields.io/github/v/tag/MagicStack/asyncpg?label=latest)](https://github.com/MagicStack/asyncpg)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python. [^asyncio-support]
 ```
 ```{sd-item}
 {tags-primary}`PG`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/MagicStack/asyncpg?label=latest)](https://github.com/MagicStack/asyncpg)
-[![](https://img.shields.io/github/actions/workflow/status/MagicStack/asyncpg/tests.yml)](https://github.com/MagicStack/asyncpg/actions/workflows/tests.yml)
 ```
 :::
 
@@ -377,16 +362,14 @@ For connecting to CrateDB from Python. [^asyncio-support]
 ```
 ```{sd-item}
 [psycopg3](https://www.psycopg.org/psycopg3/docs/)
+
+[![](https://img.shields.io/github/v/tag/psycopg/psycopg?label=latest)](https://github.com/psycopg/psycopg)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python. [^asyncio-support]
 ```
 ```{sd-item}
 {tags-primary}`PG`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/psycopg/psycopg?label=latest)](https://github.com/psycopg/psycopg)
-[![](https://img.shields.io/github/actions/workflow/status/psycopg/psycopg/tests.yml)](https://github.com/psycopg/psycopg/actions/workflows/tests.yml)
 ```
 :::
 
@@ -395,16 +378,14 @@ For connecting to CrateDB from Python. [^asyncio-support]
 ```
 ```{sd-item}
 [CrateDB Ruby driver](https://github.com/crate/crate_ruby)
+
+[![](https://img.shields.io/github/v/tag/crate/crate_ruby?label=latest)](https://github.com/crate/crate_ruby)
 ```
 ```{sd-item}
 A Ruby client library for CrateDB.
 ```
 ```{sd-item}
 {tags-success}`HTTP`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/crate/crate_ruby?label=latest)](https://github.com/crate/crate_ruby)
-[![](https://img.shields.io/github/actions/workflow/status/crate/crate_ruby/tests.yml)](https://github.com/crate/crate_ruby/actions/workflows/tests.yml)
 ```
 :::
 
@@ -413,16 +394,14 @@ A Ruby client library for CrateDB.
 ```
 ```{sd-item}
 [CrateDB ActiveRecord adapter](https://github.com/crate/activerecord-crate-adapter)
+
+[![](https://img.shields.io/github/v/tag/crate/activerecord-crate-adapter?label=latest)](https://github.com/crate/activerecord-crate-adapter)
 ```
 ```{sd-item}
 Ruby on Rails ActiveRecord adapter for CrateDB.
 ```
 ```{sd-item}
 {tags-success}`HTTP`
-```
-```{sd-item}
-[![](https://img.shields.io/github/v/tag/crate/activerecord-crate-adapter?label=latest)](https://github.com/crate/activerecord-crate-adapter)
-[![](https://img.shields.io/github/actions/workflow/status/crate/activerecord-crate-adapter/tests.yml)](https://github.com/crate/activerecord-crate-adapter/actions/workflows/tests.yml)
 ```
 :::
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,6 +184,7 @@ Machine Learning <integrate/ml>
 ```{toctree}
 :hidden:
 
+Build Status <status>
 Legacy documentation <legacy>
 ```
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,202 @@
+# Build Status
+
+The build status of relevant drivers, applications, and integrations
+for CrateDB, on one page.
+
+<style>
+table td, table td * {
+  vertical-align: top;
+}
+th, td {
+  padding-right: 1em;
+  padding-left: 1em;
+}
+</style>
+
+
+## Integrations
+
+End-to-end QA integration tests against CrateDB Nightly,
+on behalf of [cratedb-examples].
+
+<table>
+<tbody>
+
+<tr>
+<td>
+<b>Application</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/application-apache-kafka-flink.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/application-apache-kafka-flink.yml?label=Apache Kafka, Apache Flink" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/application-apache-superset.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/application-apache-superset.yml?label=Apache Superset" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Dataframe</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/dataframe-dask.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/dataframe-dask.yml?label=Dask" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/dataframe-pandas.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/dataframe-pandas.yml?label=pandas" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Language</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-npgsql.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/lang-npgsql.yml?label=npgsql" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-java-jooq.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/lang-java-jooq.yml?label=Java jOOQ" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-java-maven.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/lang-java-maven.yml?label=Java JDBC" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-php-amphp.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/lang-php-amphp.yml?label=PHP AMPHP" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-php-pdo.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/lang-php-pdo.yml?label=PHP PDO" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-python-sqlalchemy.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/lang-python-sqlalchemy.yml?label=Python SQLAlchemy" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-ruby.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/lang-ruby.yml?label=Ruby" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Testing</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/testing-testcontainers-java.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/testing-testcontainers-java.yml?label=Testcontainers for Java" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Topic</b>
+</td>
+<td>
+<b>Machine Learning</b>
+<br>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/ml-automl.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/ml-automl.yml?label=AutoML" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/ml-langchain.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/ml-langchain.yml?label=LangChain" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/ml-mlflow.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/ml-mlflow.yml?label=MLflow" loading="lazy"></a>
+</td>
+</tr>
+
+</tbody>
+</table>
+
+
+## Applications
+
+CI outcomes for a range of applications, frameworks, and libraries connecting
+to CrateDB.
+
+<table>
+<tbody>
+
+<tr>
+<td>
+<b>Framework</b>
+</td>
+<td>
+<a href="https://github.com/crate-workbench/cratedb-toolkit/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/cratedb-toolkit/main.yml?label=CrateDB Toolkit" loading="lazy"></a>
+<a href="https://github.com/crate-workbench/mlflow-cratedb/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/mlflow-cratedb/main.yml?label=MLflow for CrateDB" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Metrics</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-prometheus-adapter/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-prometheus-adapter/tests.yml?label=CrateDB Prometheus Adapter" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Operation</b>
+</td>
+<td>
+<a href="https://github.com/crate/crate-operator/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/crate-operator/main.yaml?label=CrateDB Kubernetes Operator" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>UI</b>
+</td>
+<td>
+<a href="https://github.com/crate/crate-admin/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/crate-admin/tests.yml?label=CrateDB Admin UI" loading="lazy"></a>
+<a href="https://github.com/crate/crash/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/crash/main.yml?label=Crash CLI" loading="lazy"></a>
+<a href="https://github.com/crate/croud/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/croud/main.yml?label=Croud CLI" loading="lazy"></a>
+</td>
+</tr>
+
+</tbody>
+</table>
+
+
+## Drivers
+
+CI outcomes for a range of client drivers connecting your applications to CrateDB.
+
+### CrateDB
+Drivers and dialects maintained by Crate.io.
+
+<a href="https://github.com/crate/crate-python/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/crate-python/tests.yml?label=crate-python" loading="lazy"></a>
+<a href="https://github.com/crate/crate-pdo/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/crate-pdo/tests.yml?label=crate-pdo" loading="lazy"></a>
+<a href="https://github.com/crate/crate-dbal/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/crate-dbal/tests.yml?label=crate-dbal" loading="lazy"></a>
+<a href="https://github.com/crate/crate_ruby/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/crate_ruby/tests.yml?label=crate_ruby" loading="lazy"></a>
+<a href="https://github.com/crate/activerecord-crate-adapter/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/activerecord-crate-adapter/tests.yml?label=activerecord-crate-adapter" loading="lazy"></a>
+
+### PostgreSQL
+Standard PostgreSQL drivers for different languages.
+
+<a href="https://github.com/pgjdbc/pgjdbc/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/pgjdbc/pgjdbc/main.yml?label=pgjdbc" loading="lazy"></a>
+<a href="https://github.com/npgsql/npgsql/actions/workflows/build.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/npgsql/npgsql/build.yml?label=npgsql" loading="lazy"></a>
+<a href="https://github.com/psycopg/psycopg2/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/psycopg/psycopg2/tests.yml?label=psycopg2" loading="lazy"></a>
+<a href="https://github.com/psycopg/psycopg/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/psycopg/psycopg/tests.yml?label=psycopg3" loading="lazy"></a>
+<a href="https://github.com/MagicStack/asyncpg/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/MagicStack/asyncpg/tests.yml?label=asyncpg" loading="lazy"></a>
+<a href="https://github.com/brianc/node-postgres/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/brianc/node-postgres/ci.yml?label=node-postgres" loading="lazy"></a>
+
+
+```{note}
+Please note that the designated status of drivers maintained by community
+authors and other maintainers reflect the build status of the development
+head. It does not mean integration with GA releases isn't stable. This is
+reflected within the topmost section of this page.
+```
+
+
+[cratedb-examples]: https://github.com/crate/cratedb-examples

--- a/docs/status.md
+++ b/docs/status.md
@@ -111,6 +111,8 @@ to CrateDB.
 <b>Framework</b>
 </td>
 <td>
+<a href="https://github.com/crate/cratedb-airflow-tutorial/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-airflow-tutorial/main.yml?label=Apache Airflow" loading="lazy"></a>
 <a href="https://github.com/crate-workbench/cratedb-toolkit/actions/workflows/main.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/cratedb-toolkit/main.yml?label=CrateDB Toolkit" loading="lazy"></a>
 <a href="https://github.com/crate-workbench/mlflow-cratedb/actions/workflows/main.yml">

--- a/docs/status.md
+++ b/docs/status.md
@@ -115,6 +115,10 @@ to CrateDB.
     <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-airflow-tutorial/main.yml?label=Apache Airflow" loading="lazy"></a>
 <a href="https://github.com/crate-workbench/cratedb-toolkit/actions/workflows/main.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/cratedb-toolkit/main.yml?label=CrateDB Toolkit" loading="lazy"></a>
+<a href="https://github.com/crate-workbench/cratedb-toolkit/actions/workflows/influxdb.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/cratedb-toolkit/influxdb.yml?label=Toolkit%2BInfluxDB" loading="lazy"></a>
+<a href="https://github.com/crate-workbench/cratedb-toolkit/actions/workflows//mongodb.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/cratedb-toolkit/mongodb.yml?label=Toolkit%2BMongoDB" loading="lazy"></a>
 <a href="https://github.com/crate-workbench/mlflow-cratedb/actions/workflows/main.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/mlflow-cratedb/main.yml?label=MLflow for CrateDB" loading="lazy"></a>
 </td>


### PR DESCRIPTION
## About
The build status of relevant drivers, applications, and integrations for CrateDB, on one page. Will make parts of https://github.com/crate/cratedb-examples/pull/277 obsolete again.

## Review
Maybe you can spot some missing item you would like to see enumerated here?

## Preview
https://crate-clients-tools--75.org.readthedocs.build/en/75/status.html

/cc @karynzv, @marijaselakovic, @hlcianfagna, @wierdvanderhaar 