### PR TITLE
Chore: Use cratedb.com, and https:// everywhere

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,8 +7,8 @@
 - [ ] Connect: Add more properties, like `schema`
 - [ ] ETL: There is pandas, but not Dask/Coiled
 - [ ] Add Prometheus
-  - https://crate.io/integrations/cratedb-and-prometheus
-  - https://community.crate.io/t/storing-long-term-metrics-with-prometheus-in-cratedb/1012
+  - https://cratedb.com/integrations/cratedb-and-prometheus
+  - https://community.cratedb.com/t/storing-long-term-metrics-with-prometheus-in-cratedb/1012
   - https://github.com/crate/cratedb-prometheus-adapter
 
 ## Iteration +2
@@ -17,7 +17,7 @@
   - Terraform (Administration)
 - [ ] Add section about testing frameworks
 - [ ] Add section "highlights", or "awesome", bundling corresponding resources.
-  - https://community.crate.io/t/how-we-scaled-ingestion-to-one-million-rows-per-second/1069
+  - https://community.cratedb.com/t/how-we-scaled-ingestion-to-one-million-rows-per-second/1069
 - [ ] Add [HTTPie Desktop]
   Screenshot: https://github.com/crate/crate-clients-tools/assets/453543/9f724518-ee83-43ac-9ea1-7be63e7c9805
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -62,7 +62,7 @@ release version), please contact the `@crate/tech-writing`_ team.
 .. _fswatch: https://github.com/emcrisostomo/fswatch
 .. _Read the Docs: https://readthedocs.org
 .. _ReStructuredText: https://docutils.sourceforge.net/rst.html
-.. _Sphinx: https://sphinx-doc.org/
+.. _Sphinx: https://www.sphinx-doc.org
 
 
 .. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcrate-clients-toolss%2Fmain%2Fdocs%2Fbuild.json

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -60,9 +60,9 @@ release version), please contact the `@crate/tech-writing`_ team.
 .. _@crate/tech-writing: https://github.com/orgs/crate/teams/tech-writing
 .. _configured: https://github.com/crate/crate-clients-tools/blob/main/.github/workflows/docs.yml
 .. _fswatch: https://github.com/emcrisostomo/fswatch
-.. _Read the Docs: http://readthedocs.org
-.. _ReStructuredText: http://docutils.sourceforge.net/rst.html
-.. _Sphinx: http://sphinx-doc.org/
+.. _Read the Docs: https://readthedocs.org
+.. _ReStructuredText: https://docutils.sourceforge.net/rst.html
+.. _Sphinx: https://sphinx-doc.org/
 
 
 .. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcrate-clients-toolss%2Fmain%2Fdocs%2Fbuild.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@ Looking for help?
 
 
 .. _contribution docs: CONTRIBUTING.rst
-.. _community forum: https://community.crate.io/
-.. _Crate.io: http://crate.io/
-.. _CrateDB: https://crate.io/products/cratedb/
-.. _CrateDB integration tutorials: https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015
+.. _community forum: https://community.cratedb.com/
+.. _Crate.io: https://cratedb.com/
+.. _CrateDB: https://cratedb.com/products/cratedb/
+.. _CrateDB integration tutorials: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
 .. _developer docs: DEVELOP.rst
-.. _live docs: https://crate.io/docs/crate/clients-tools/en/latest/
-.. _support channels: https://crate.io/support/
+.. _live docs: https://cratedb.com/docs/crate/clients-tools/en/latest/
+.. _support channels: https://cratedb.com/support/

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Looking for help?
 .. _contribution docs: CONTRIBUTING.rst
 .. _community forum: https://community.cratedb.com/
 .. _Crate.io: https://cratedb.com/
-.. _CrateDB: https://cratedb.com/products/cratedb/
+.. _CrateDB: https://cratedb.com/product
 .. _CrateDB integration tutorials: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
 .. _developer docs: DEVELOP.rst
 .. _live docs: https://cratedb.com/docs/crate/clients-tools/en/latest/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.  You may
 # obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/docs/connect/cli.md
+++ b/docs/connect/cli.md
@@ -22,7 +22,7 @@ When using CrateDB Cloud, `<hostname>` will be something like
 
 ```{div}
 :style: "float: right"
-![image](https://crate.io/docs/crate/crash/en/latest/_images/query.png){w=240px}
+![image](https://cratedb.com/docs/crate/crash/en/latest/_images/query.png){w=240px}
 ```
 
 The **CrateDB Shell** is an interactive command-line interface (CLI) tool for

--- a/docs/connect/ide.md
+++ b/docs/connect/ide.md
@@ -24,6 +24,6 @@ article [Blog: Use CrateDB With DBeaver] explains how it works.
 
 
 
-[Blog: Use CrateDB With DataGrip]: https://crate.io/blog/use-cratedb-with-datagrip-an-advanced-database-ide
-[Blog: Use CrateDB With DBeaver]: https://crate.io/blog/cratedb-dbeaver
+[Blog: Use CrateDB With DataGrip]: https://cratedb.com/blog/use-cratedb-with-datagrip-an-advanced-database-ide
+[Blog: Use CrateDB With DBeaver]: https://cratedb.com/blog/cratedb-dbeaver
 [DBeaver]: https://dbeaver.io/

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -183,7 +183,7 @@ Visual Basic, and F#.
 ```{sd-item} .NET
 ```
 ```{sd-item}
-[CrateDB Npgsql fork](https://crate.io/docs/npgsql/)
+[CrateDB Npgsql fork](https://cratedb.com/docs/npgsql/)
 ```
 ```{sd-item}
 This fork of the official driver was needed prior to CrateDB 4.2.
@@ -229,7 +229,7 @@ For connecting to CrateDB from any environment that supports it.
 ```{sd-item} Java
 ```
 ```{sd-item}
-[CrateDB PgJDBC fork](https://crate.io/docs/jdbc/)
+[CrateDB PgJDBC fork](https://cratedb.com/docs/jdbc/)
 ```
 ```{sd-item}
 For connecting to CrateDB with specialized type system support and
@@ -362,7 +362,7 @@ A JavaScript library connecting to the CrateDB HTTP API.
 ```{sd-item} PHP
 ```
 ```{sd-item}
-[CrateDB PDO driver](https://crate.io/docs/pdo/)
+[CrateDB PDO driver](https://cratedb.com/docs/pdo/)
 ```
 ```{sd-item}
 For connecting to CrateDB from PHP.
@@ -377,7 +377,7 @@ For connecting to CrateDB from PHP.
 ```{sd-item} PHP
 ```
 ```{sd-item}
-[CrateDB DBAL adapter](https://crate.io/docs/dbal/)
+[CrateDB DBAL adapter](https://cratedb.com/docs/dbal/)
 ```
 ```{sd-item}
 For connecting to CrateDB from PHP, using DBAL and Doctrine.
@@ -392,7 +392,7 @@ For connecting to CrateDB from PHP, using DBAL and Doctrine.
 ```{sd-item} Python
 ```
 ```{sd-item}
-[CrateDB Python driver](https://crate.io/docs/python/)
+[CrateDB Python driver](https://cratedb.com/docs/python/)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python. Has support for [CrateDB BLOBs].
@@ -408,7 +408,7 @@ For connecting to CrateDB from Python. Has support for [CrateDB BLOBs].
 ```{sd-item} Python
 ```
 ```{sd-item}
-[SQLAlchemy dialect](https://crate.io/docs/python/en/latest/sqlalchemy.html)
+[SQLAlchemy dialect](https://cratedb.com/docs/python/en/latest/sqlalchemy.html)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python, using SQLAlchemy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ machine learning, and more.
 :gutter: 1
 
 :::{grid-item-card} {material-outlined}`integration_instructions;2em` Overview
-:link: https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015
+:link: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
 :link-type: url
 
 Learn how to use CrateDB with popular applications, frameworks, and tools.
@@ -190,4 +190,4 @@ Legacy documentation <legacy>
 ```
 
 
-[get in touch]: https://crate.io/contact
+[get in touch]: https://cratedb.com/contact

--- a/docs/integrate/bi.md
+++ b/docs/integrate/bi.md
@@ -26,9 +26,9 @@ you through the process of configuring that correctly.
 possible to publish your dashboards, in order to share them with others.
 [](inv:guide#powerbi-service) has a corresponding tutorial.
 
-![](https://crate.io/docs/crate/howtos/en/latest/_images/powerbi-table-navigator.png){h=160px}
-![](https://crate.io/docs/crate/howtos/en/latest/_images/powerbi-pie-chart.png){h=160px}
-![](https://crate.io/docs/crate/howtos/en/latest/_images/powerbi-publish-success.png){h=160px}
+![](https://cratedb.com/docs/crate/howtos/en/latest/_images/powerbi-table-navigator.png){h=160px}
+![](https://cratedb.com/docs/crate/howtos/en/latest/_images/powerbi-pie-chart.png){h=160px}
+![](https://cratedb.com/docs/crate/howtos/en/latest/_images/powerbi-publish-success.png){h=160px}
 
 ```{seealso}
 [CrateDB and Power BI]
@@ -49,19 +49,19 @@ data by translating drag-and-drop actions into data queries through an intuitive
 [Connecting to CrateDB from Tableau with JDBC] and [Using CrateDB with Tableau] will
 guide you through the process of setting it up correctly with CrateDB.
 
-![](https://crate.io/hs-fs/hubfs/08-index.png?width=1536&name=08-index.png){h=200px}
+![](https://cratedb.com/hs-fs/hubfs/08-index.png?width=1536&name=08-index.png){h=200px}
 
 ```{seealso}
 [CrateDB and Tableau]
 ```
 
 
-[Connecting to CrateDB from Tableau with JDBC]: https://crate.io/blog/connecting-to-cratedb-from-tableau-with-jdbc
-[CrateDB and Tableau]: https://crate.io/integrations/cratedb-and-tableau
-[CrateDB and Power BI]: https://crate.io/integrations/cratedb-and-power-bi
+[Connecting to CrateDB from Tableau with JDBC]: https://cratedb.com/blog/connecting-to-cratedb-from-tableau-with-jdbc
+[CrateDB and Tableau]: https://cratedb.com/integrations/cratedb-and-tableau
+[CrateDB and Power BI]: https://cratedb.com/integrations/cratedb-and-power-bi
 [PostgreSQL ODBC driver]: https://odbc.postgresql.org/
 [Power BI Desktop]: https://powerbi.microsoft.com/en-us/desktop/
 [Power BI Service]: https://powerbi.microsoft.com/en-us/
 [Power Query PostgreSQL connector]: https://learn.microsoft.com/en-us/power-query/connectors/postgresql
 [Tableau]: https://www.tableau.com/
-[Using CrateDB with Tableau]: https://community.crate.io/t/using-cratedb-with-tableau/1192
+[Using CrateDB with Tableau]: https://community.cratedb.com/t/using-cratedb-with-tableau/1192

--- a/docs/integrate/etl.md
+++ b/docs/integrate/etl.md
@@ -330,10 +330,10 @@ an SSIS Catalog database to store, run, and manage packages.
 [Astronomer]: https://www.astronomer.io/
 [Azure Event Hubs for Apache Kafka]: https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-kafka-overview
 [Confluent Cloud]: https://www.confluent.io/confluent-cloud/
-[CrateDB and Apache Airflow]: https://crate.io/integrations/cratedb-and-apache-airflow
-[CrateDB and Apache Kafka]: https://crate.io/integrations/cratedb-and-kafka
-[CrateDB and Kestra]: https://crate.io/integrations/cratedb-and-kestra
-[CrateDB and Node-RED]: https://crate.io/integrations/cratedb-and-node-red
+[CrateDB and Apache Airflow]: https://cratedb.com/integrations/cratedb-and-apache-airflow
+[CrateDB and Apache Kafka]: https://cratedb.com/integrations/cratedb-and-kafka
+[CrateDB and Kestra]: https://cratedb.com/integrations/cratedb-and-kestra
+[CrateDB and Node-RED]: https://cratedb.com/integrations/cratedb-and-node-red
 [CrateDB Guide: Integration Tutorials]: inv:guide:*:label#integrate
 [dbt]: https://www.getdbt.com/
 [dbt Cloud]: https://www.getdbt.com/product/dbt-cloud/

--- a/docs/integrate/metrics.md
+++ b/docs/integrate/metrics.md
@@ -99,7 +99,7 @@ a very minimal memory footprint.
 
 
 [CrateDB and Prometheus]: https://cratedb.com/integrations/cratedb-and-prometheus
-[CrateDB and Telegraf]: https://crate.io/integrations/cratedb-and-telegraf
+[CrateDB and Telegraf]: https://cratedb.com/integrations/cratedb-and-telegraf
 [CrateDB Guide: Integration Tutorials]: inv:guide:*:label#integrate
 [CrateDB Prometheus Adapter]: https://github.com/crate/cratedb-prometheus-adapter
 [Prometheus]: https://prometheus.io/

--- a/docs/integrate/visualize.md
+++ b/docs/integrate/visualize.md
@@ -12,7 +12,7 @@ visualizing data stored inside CrateDB.
 
 ```{div}
 :style: "float: right"
-[![](https://crate.io/hs-fs/hubfs/Apache-Superset-Logo-392x140@2x.png?width=604&height=216&name=Apache-Superset-Logo-392x140@2x.png){w=180px}](https://superset.apache.org/)
+[![](https://cratedb.com/hs-fs/hubfs/Apache-Superset-Logo-392x140@2x.png?width=604&height=216&name=Apache-Superset-Logo-392x140@2x.png){w=180px}](https://superset.apache.org/)
 
 [![](https://github.com/crate/crate-clients-tools/assets/453543/9d07da87-8aff-4569-bf2a-0a16bf89f4bc){w=180px}](https://preset.io/)
 ```
@@ -147,15 +147,15 @@ run white-labeled data portals.
 :style: "clear: both"
 ```
 
-![](https://crate.io/hs-fs/hubfs/Screenshot%202023-07-21%20at%2013.17.45.png?width=2948&height=2312&name=Screenshot%202023-07-21%20at%2013.17.45.png){h=200px}
-![](https://crate.io/hs-fs/hubfs/Screenshot%202023-07-21%20at%2013.24.01.png?width=2932&height=1716&name=Screenshot%202023-07-21%20at%2013.24.01.png){h=200px}
+![](https://cratedb.com/hs-fs/hubfs/Screenshot%202023-07-21%20at%2013.17.45.png?width=2948&height=2312&name=Screenshot%202023-07-21%20at%2013.17.45.png){h=200px}
+![](https://cratedb.com/hs-fs/hubfs/Screenshot%202023-07-21%20at%2013.24.01.png?width=2932&height=1716&name=Screenshot%202023-07-21%20at%2013.24.01.png){h=200px}
 
 
 ## Grafana
 
 ```{div}
 :style: "float: right"
-[![](https://crate.io/hs-fs/hubfs/Imported_Blog_Media/grafana-logo-1-520x126.png?width=1040&height=252&name=grafana-logo-1-520x126.png){w=180px}](https://grafana.com/grafana/)
+[![](https://cratedb.com/hs-fs/hubfs/Imported_Blog_Media/grafana-logo-1-520x126.png?width=1040&height=252&name=grafana-logo-1-520x126.png){w=180px}](https://grafana.com/grafana/)
 ```
 
 [Grafana OSS] is the leading open-source metrics visualization tool that helps you
@@ -179,7 +179,7 @@ how to run a database query.
 :::{dropdown} **Managed Grafana**
 ```{div}
 :style: "float: right"
-[![](https://crate.io/hs-fs/hubfs/Imported_Blog_Media/grafana-logo-1-520x126.png?width=1040&height=252&name=grafana-logo-1-520x126.png){w=180px}](https://grafana.com/grafana/)
+[![](https://cratedb.com/hs-fs/hubfs/Imported_Blog_Media/grafana-logo-1-520x126.png?width=1040&height=252&name=grafana-logo-1-520x126.png){w=180px}](https://grafana.com/grafana/)
 ```
 
 Get Grafana fully managed with [Grafana Cloud].
@@ -301,9 +301,9 @@ Based on Plotly, [Dash] is a low-code framework for rapidly building data apps i
 
 [Apache Superset]: https://superset.apache.org/
 [Cluvio]: https://www.cluvio.com/
-[CrateDB and Grafana]: https://crate.io/integrations/cratedb-and-grafana 
-[CrateDB and Superset]: https://crate.io/integrations/cratedb-and-apache-superset 
-[CrateDB and Metabase]: https://crate.io/integrations/cratedb-and-metabase
+[CrateDB and Grafana]: https://cratedb.com/integrations/cratedb-and-grafana
+[CrateDB and Superset]: https://cratedb.com/integrations/cratedb-and-apache-superset
+[CrateDB and Metabase]: https://cratedb.com/integrations/cratedb-and-metabase
 [Dash]: https://plotly.com/dash/
 [Datashader]: https://datashader.org/
 [Explo]: https://www.explo.co/

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -150,7 +150,7 @@ CrateDB integrates with many different tools. Some of these are:
 - **Pentaho**
 
   `Pentaho`_ prepares and blends data, delivering business analytics from any
-  source. You can connect to CrateDB clusters by using `Petaho Kettle`_ and the
+  source. You can connect to CrateDB clusters by using `Pentaho Kettle`_ and the
   standalone version of `our JDBC driver`_.
 
 - **R**
@@ -185,48 +185,48 @@ CrateDB integrates with many different tools. Some of these are:
 
 .. _activerecord-crate-adaptor: https://rubygems.org/gems/activerecord-crate-adapter
 .. _asyncpg: https://github.com/MagicStack/asyncpg
-.. _Authenticate: https://crate.io/docs/crate/reference/en/latest/admin/auth/index.html
+.. _Authenticate: https://cratedb.com/docs/crate/reference/en/latest/admin/auth/index.html
 .. _Azure Function: https://azure.microsoft.com/en-in/services/functions/
-.. _building data stream pipelines: https://crate.io/docs/crate/howtos/en/latest/integrations/streamsets.html
-.. _client compatibility notes: https://crate.io/docs/crate/reference/en/latest/interfaces/postgres.html#client-compatibility
+.. _building data stream pipelines: https://cratedb.com/docs/crate/howtos/en/latest/integrations/streamsets.html
+.. _client compatibility notes: https://cratedb.com/docs/crate/reference/en/latest/interfaces/postgres.html#client-compatibility
 .. _crate-connect: https://www.npmjs.com/package/crate-connect
-.. _CrateDB Npgsql fork: https://crate.io/docs/clients/npgsql/en/latest/
-.. _CrateDB PDO: https://crate.io/docs/clients/pdo/en/latest/
-.. _CrateDB DBAL: https://crate.io/docs/clients/dbal/en/latest/
+.. _CrateDB Npgsql fork: https://cratedb.com/docs/clients/npgsql/en/latest/
+.. _CrateDB PDO: https://cratedb.com/docs/clients/pdo/en/latest/
+.. _CrateDB DBAL: https://cratedb.com/docs/clients/dbal/en/latest/
 .. _CrateDB driver for Laravel: https://github.com/RatkoR/laravel-crate.io
-.. _CrateDB integration tutorials: https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015
-.. _crate-jdbc: https://crate.io/docs/clients/jdbc/en/latest/
+.. _CrateDB integration tutorials: https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015
+.. _crate-jdbc: https://cratedb.com/docs/clients/jdbc/en/latest/
 .. _cratejs: https://www.npmjs.com/package/cratejs
-.. _crate-python: https://crate.io/docs/clients/python/en/latest/
+.. _crate-python: https://cratedb.com/docs/clients/python/en/latest/
 .. _craterl: https://github.com/crate/craterl
 .. _crate_ruby: https://rubygems.org/gems/crate_ruby
 .. _crate-scala: https://github.com/alexanderjarvis/crate-scala
 .. _crate-connector: https://github.com/LiamHaworth/crate-connector
-.. _create a data enrichment pipeline: https://crate.io/docs/crate/howtos/en/latest/integrations/azure-functions.html
-.. _create a Machine Learning pipeline: https://crate.io/docs/crate/howtos/en/latest/integrations/r.html
+.. _create a data enrichment pipeline: https://cratedb.com/docs/crate/howtos/en/latest/integrations/azure-functions.html
+.. _create a Machine Learning pipeline: https://cratedb.com/docs/crate/howtos/en/latest/integrations/r.html
 .. _DBD::Crate: https://github.com/mamod/DBD-Crate
-.. _get in touch: https://crate.io/contact
+.. _get in touch: https://cratedb.com/contact
 .. _GitHub: https://github.com/crate/crate-clients-tools
 .. _Grafana: https://grafana.com
-.. _implementation differences: https://crate.io/docs/crate/reference/en/latest/interfaces/postgres.html#implementation-differences
-.. _integrations: https://crate.io/blog/tag/integrations
-.. _integrations section: https://crate.io/docs/crate/howtos/en/latest/integrations/index.html
-.. _let us know: https://crate.io/contact
+.. _implementation differences: https://cratedb.com/docs/crate/reference/en/latest/interfaces/postgres.html#implementation-differences
+.. _integrations: https://cratedb.com/blog/tag/integrations
+.. _integrations section: https://cratedb.com/docs/crate/howtos/en/latest/integrations/index.html
+.. _let us know: https://cratedb.com/contact
 .. _node-crate: https://www.npmjs.com/package/node-crate
 .. _node-postgres: https://node-postgres.com/
 .. _Npgsql: https://www.npgsql.org/
-.. _our JDBC driver: https://crate.io/docs/reference/jdbc
-.. _pair CrateDB with Grafana: https://crate.io/blog/visualizing-time-series-data-with-grafana-and-cratedb
-.. _Pentaho: http://www.pentaho.com
-.. _Petaho Kettle: https://github.com/pentaho/pentaho-kettle
+.. _our JDBC driver: https://cratedb.com/docs/reference/jdbc
+.. _pair CrateDB with Grafana: https://cratedb.com/blog/visualizing-time-series-data-with-grafana-and-cratedb
+.. _Pentaho: https://www.pentaho.com
+.. _Pentaho Kettle: https://github.com/pentaho/pentaho-kettle
 .. _pgx: https://github.com/jackc/pgx
 .. _PostgreSQL JDBC: https://jdbc.postgresql.org/
-.. _PostgreSQL wire protocol: https://crate.io/docs/crate/reference/en/latest/interfaces/postgres.html
+.. _PostgreSQL wire protocol: https://cratedb.com/docs/crate/reference/en/latest/interfaces/postgres.html
 .. _R: https://www.r-project.org
-.. _schema: https://crate.io/docs/crate/reference/en/latest/general/ddl/create-table.html#schemas
-.. _set up CrateDB with SQLPad: https://crate.io/blog/use-cratedb-with-sqlpad-as-a-self-hosted-query-tool-and-visualizer
-.. _SQLAlchemy: https://crate.io/docs/clients/python/en/latest/sqlalchemy.html
+.. _schema: https://cratedb.com/docs/crate/reference/en/latest/general/ddl/create-table.html#schemas
+.. _set up CrateDB with SQLPad: https://cratedb.com/blog/use-cratedb-with-sqlpad-as-a-self-hosted-query-tool-and-visualizer
+.. _SQLAlchemy: https://cratedb.com/docs/clients/python/en/latest/sqlalchemy.html
 .. _SQLPad: https://github.com/sqlpad/sqlpad
 .. _StreamSets: https://streamsets.com/opensource
-.. _superuser: https://crate.io/docs/crate/reference/en/latest/admin/user-management.html
+.. _superuser: https://cratedb.com/docs/crate/reference/en/latest/admin/user-management.html
 .. _with known issues: https://github.com/crate/crate/issues?q=is%3Aopen+is%3Aissue+label%3A%22client%3A+PostgreSQL+JDBC%22


### PR DESCRIPTION
## About

Rename all references to crate.io to cratedb.com, where applicable. Also, use `https://` everywhere where `http://` has been used before.
