### PR TITLE
Client Drivers: Add `aiopg` to list of supported Python drivers

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -296,6 +296,21 @@ designed with fibers and concurrency in mind.
 ```{sd-item} Python
 ```
 ```{sd-item}
+[aoipg](https://github.com/aio-libs/aiopg)
+```
+```{sd-item}
+For connecting to CrateDB from Python, supporting Python's `asyncio` (PEP-3156/tulip) framework.
+```
+```{sd-item}
+[![](https://img.shields.io/github/v/tag/aio-libs/aiopg?label=latest)](https://github.com/aio-libs/aiopg)
+[![](https://img.shields.io/badge/example-snippet-darkcyan)](#aiopg)
+```
+:::
+
+:::{sd-row}
+```{sd-item} Python
+```
+```{sd-item}
 [asyncpg](https://github.com/MagicStack/asyncpg)
 ```
 ```{sd-item}

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -318,7 +318,7 @@ For connecting to CrateDB from Python, supporting Python's `asyncio`.
 ```
 ```{sd-item}
 [![](https://img.shields.io/github/v/tag/MagicStack/asyncpg?label=latest)](https://github.com/MagicStack/asyncpg)
-[![](https://img.shields.io/badge/example-snippet-darkcyan)](#python)
+[![](https://img.shields.io/badge/example-snippet-darkcyan)](#psycopg2)
 ```
 :::
 
@@ -333,7 +333,7 @@ For connecting to CrateDB from Python, supporting Python's `asyncio`.
 ```
 ```{sd-item}
 [![](https://img.shields.io/github/v/tag/psycopg/psycopg?label=latest)](https://github.com/psycopg/psycopg)
-[![](https://img.shields.io/badge/example-snippet-darkcyan)](#python)
+[![](https://img.shields.io/badge/example-snippet-darkcyan)](#psycopg3)
 ```
 :::
 

--- a/docs/connect/python.rst
+++ b/docs/connect/python.rst
@@ -76,6 +76,7 @@ more modern PostgreSQL and Python features, such as:
 	        for record in cursor:
 	            print(record)
 
+.. _aiopg:
 
 aiopg
 -----

--- a/docs/connect/python.rst
+++ b/docs/connect/python.rst
@@ -8,6 +8,8 @@ This guide demonstrates how to connect to a CrateDB Cloud cluster using differen
 kinds of Python drivers. Individual drivers offer specific features for specific
 needs of your application, so consider reading this enumeration carefully.
 
+.. _crate-python:
+
 crate-python
 ------------
 
@@ -24,9 +26,11 @@ The package can be installed using ``pip install crate[sqlalchemy]``.
 
 	with conn:
 	    cursor = conn.cursor()
-	    cursor.execute("SELECT name FROM sys.cluster")
+	    cursor.execute("SELECT * FROM sys.summits")
 	    result = cursor.fetchone()
 	    print(result)
+
+.. _psycopg2:
 
 psycopg2
 --------
@@ -44,9 +48,11 @@ For more information, see the `psycopg documentation`_.
 
 	with conn:
 	    with conn.cursor() as cursor:
-	        cursor.execute("SELECT name FROM sys.cluster")
+	        cursor.execute("SELECT * FROM sys.summits")
 	        result = cursor.fetchone()
 	        print(result)
+
+.. _psycopg3:
 
 psycopg3
 --------
@@ -95,12 +101,14 @@ For more information, see the `aiopg documentation`_.
 	    async with aiopg.create_pool(host="<name-of-your-cluster>.cratedb.net", port=5432, user="admin", password="<PASSWORD>", sslmode="require") as pool:
 	        async with pool.acquire() as conn:
 	            async with conn.cursor() as cursor:
-	                await cursor.execute("SELECT name FROM sys.cluster")
+	                await cursor.execute("SELECT * FROM sys.summits")
 	                result = await cursor.fetchone()
 	    print(result)
 
 	loop = asyncio.get_event_loop()
 	loop.run_until_complete(run())
+
+.. _asyncpg:
 
 asyncpg
 -------
@@ -118,7 +126,7 @@ For more information, see the `asyncpg documentation`_.
 	async def run():
 	    conn = await asyncpg.connect(host="<name-of-your-cluster>.cratedb.net", port=5432, user="admin", password="<PASSWORD>", ssl=True)
 	    try:
-	        result = await conn.fetch("SELECT name FROM sys.cluster")
+	        result = await conn.fetch("SELECT * FROM sys.summits")
 	    finally:
 	        await conn.close()
 	    print(result)


### PR DESCRIPTION
## About
- We found [aiopg](https://github.com/aio-libs/aiopg) has not been enumerated in the list of canonical supported client drivers for Python.
- Along the lines, the patch improves a a few spots in the same area while on it already.
