### PR TITLE
ETL: Add Apache NiFi

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,8 @@ linkcheck_ignore = [
     "https://www.microsoft.com",
     # 500 Server Error: Internal Server Error for url
     "https://sigmod.org/",
+    # 403 Client Error: Forbidden for url
+    "https://www.datanami.com/",
 ]
 
 linkcheck_timeout = 5

--- a/docs/integrate/etl.md
+++ b/docs/integrate/etl.md
@@ -127,9 +127,6 @@ orchestration.
 ![](https://github.com/crate/crate-clients-tools/assets/453543/60cfc82a-db0a-49f1-8e26-a37b774b3614){h=120px}
 ![](https://github.com/crate/crate-clients-tools/assets/453543/2bd59577-b664-45ae-a71e-36a130d36739){h=120px}
 
-```{seealso}
-[CrateDB and Apache Hop]
-```
 
 
 ## Apache Kafka
@@ -158,6 +155,33 @@ them all, see the [overview about more managed Kafka offerings].
 - [Confluent Cloud]
 - [DoubleCloud Managed Service for Apache Kafka]
 :::
+
+
+## Apache NiFi
+
+```{div}
+:style: "float: right; margin-left: 0.3em"
+[![](https://nifi.apache.org/images/apache-nifi-drop-logo.svg){w=180px}](https://nifi.apache.org/)
+```
+
+[Apache NiFi] is an easy to use, powerful, and reliable system to process and
+distribute data. NiFi automates cybersecurity, observability, event streams,
+and generative AI data pipelines and distribution for thousands of companies
+worldwide across every industry.
+
+- **Data provenance tracking**: Complete lineage of information from beginning to end.
+- **Extensive configuration**: Loss-tolerant and guaranteed delivery, Low latency and
+  high throughput, Dynamic prioritization, Runtime modification of flow configuration,
+  Back pressure control.
+- **Browser-based user interface**: Seamless experience for design, control, feedback,
+  and monitoring
+- **Secure communication**: HTTPS with configurable authentication strategies,
+  Multi-tenant authorization and policy management, Standard protocols for encrypted
+  communication including TLS and SSH.
+
+![](https://github.com/crate/crate-clients-tools/assets/453543/ba6973dd-2eec-4f1f-a436-96aac7eb9892){h=120px}
+![](https://github.com/crate/crate-clients-tools/assets/453543/7fd4d2e7-98bc-44ee-b441-e1835016ab4d){h=120px}
+![](https://github.com/crate/crate-clients-tools/assets/453543/ccfa4ac7-0d60-432f-b952-2b50789cd325){h=120px}
 
 
 ## dbt
@@ -372,6 +396,7 @@ an SSIS Catalog database to store, run, and manage packages.
 [Apache Hop]: https://hop.apache.org/
 [Apache Kafka]: https://kafka.apache.org/
 [Apache Kafka on Azure]: https://azuremarketplace.microsoft.com/marketplace/consulting-services/canonical.0001-com-ubuntu-managed-kafka
+[Apache NiFi]: https://nifi.apache.org/
 [Astronomer]: https://www.astronomer.io/
 [Azure Event Hubs for Apache Kafka]: https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-kafka-overview
 [Confluent Cloud]: https://www.confluent.io/confluent-cloud/


### PR DESCRIPTION
## About
Now after adding the item about [Apache Hop](https://github.com/crate/crate-clients-tools/pull/64), let's also add an item about Apache NiFi.

## Preview
https://crate-clients-tools--125.org.readthedocs.build/en/125/integrate/etl.html#apache-nifi