### PR TITLE
Python: Add new project `sqlalchemy-cratedb`

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -415,7 +415,7 @@ For connecting to CrateDB from Python. Has support for [CrateDB BLOBs].
 ```{sd-item}
 [![](https://img.shields.io/github/v/tag/crate/crate-python?label=latest)](https://github.com/crate/crate-python)
 [![](https://img.shields.io/badge/docs-by%20example-darkgreen)][python-dbapi-by-example]
-[![](https://img.shields.io/badge/example-snippet-darkcyan)](#python)
+[![](https://img.shields.io/badge/example-snippet-darkcyan)](#crate-python)
 ```
 :::
 
@@ -423,15 +423,15 @@ For connecting to CrateDB from Python. Has support for [CrateDB BLOBs].
 ```{sd-item} Python
 ```
 ```{sd-item}
-[SQLAlchemy dialect](https://cratedb.com/docs/python/en/latest/sqlalchemy.html)
+[SQLAlchemy dialect](https://cratedb.com/docs/sqlalchemy-cratedb/)
 ```
 ```{sd-item}
 For connecting to CrateDB from Python, using SQLAlchemy.
 ```
 ```{sd-item}
-[![](https://img.shields.io/github/v/tag/crate/crate-python?label=latest)](https://github.com/crate/crate-python)
+[![](https://img.shields.io/github/v/tag/crate/sqlalchemy-cratedb?label=latest)](https://github.com/crate/sqlalchemy-cratedb)
 [![](https://img.shields.io/badge/docs-by%20example-darkgreen)][python-sqlalchemy-by-example]
-[![](https://img.shields.io/badge/example-snippet-darkcyan)](#python)
+[![](https://img.shields.io/badge/example-snippet-darkcyan)](#sqlalchemy-cratedb)
 ```
 :::
 
@@ -497,6 +497,6 @@ ruby
 [ODBC]: https://en.wikipedia.org/wiki/Open_Database_Connectivity
 [PostgreSQL wire protocol]: https://www.postgresql.org/docs/current/protocol.html
 [python-dbapi-by-example]: inv:crate-python:*:label#by-example
-[python-sqlalchemy-by-example]: inv:crate-python:*:label#sqlalchemy-by-example
+[python-sqlalchemy-by-example]: inv:sqlalchemy-cratedb:*:label#by-example
 [schema]: inv:crate-reference:*:label#ddl-create-table-schemas
 [superuser]: inv:crate-reference:*:label#administration_user_management

--- a/docs/connect/python.rst
+++ b/docs/connect/python.rst
@@ -16,7 +16,7 @@ crate-python
 The ``crate`` Python package offers a database client implementation compatible
 with the Python Database API 2.0 specification, and also includes the CrateDB
 SQLAlchemy dialect. See the full documentation :ref:`here <crate-python:index>`.
-The package can be installed using ``pip install crate[sqlalchemy]``.
+The package can be installed using ``pip install crate``.
 
 .. code-block:: python
 
@@ -29,6 +29,27 @@ The package can be installed using ``pip install crate[sqlalchemy]``.
 	    cursor.execute("SELECT * FROM sys.summits")
 	    result = cursor.fetchone()
 	    print(result)
+
+.. _sqlalchemy-cratedb:
+
+sqlalchemy-cratedb
+------------------
+
+The `SQLAlchemy`_ dialect for CrateDB, based on the HTTP-based DBAPI client
+library `crate-python`_.
+See the full documentation :ref:`here <sqlalchemy-cratedb:index>`.
+The package can be installed using ``pip install sqlalchemy-cratedb``.
+
+.. code-block:: python
+
+    import sqlalchemy as sa
+
+    engine = sa.create_engine("crate://localhost:4200", echo=True)
+    connection = engine.connect()
+
+    result = connection.execute(sa.text("SELECT * FROM sys.summits;"))
+    for record in result.all():
+        print(record)
 
 .. _psycopg2:
 
@@ -139,3 +160,4 @@ For more information, see the `asyncpg documentation`_.
 .. _asyncpg documentation: https://magicstack.github.io/asyncpg/current/
 .. _psycopg documentation: https://www.psycopg.org/docs/
 .. _Psycopg 3: https://www.psycopg.org/psycopg3/docs/
+.. _SQLAlchemy: https://www.sqlalchemy.org/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme==0.32.4dev2


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch intends to accompany the migration.
