### PR TITLE
Added MicroPython client to list of HTTP protocol clients.

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -359,6 +359,20 @@ The drivers listed in this section all use the [CrateDB HTTP interface].
 :::
 
 :::{sd-row}
+```{sd-item} MicroPython
+```
+```{sd-item}
+[micropython-cratedb](https://github.com/crate/micropython-cratedb)
+```
+```{sd-item}
+A MicroPython library connecting to the CrateDB HTTP API.
+```
+```{sd-item}
+[![](https://img.shields.io/github/v/tag/crate/micropython-cratedb?label=latest)](https://github.com/crate/micropython-cratedb)
+```
+:::
+
+:::{sd-row}
 ```{sd-item} Node.js
 ```
 ```{sd-item}

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -383,7 +383,7 @@ A JavaScript library connecting to the CrateDB HTTP API.
 ```
 ```{sd-item}
 [![](https://img.shields.io/github/v/tag/megastef/node-crate?label=latest)](https://github.com/megastef/node-crate)
-[![](https://img.shields.io/badge/example-application-darkcyan)](https://github.com/simonprickett/cratedb-demo)
+[![](https://img.shields.io/badge/example-application-darkcyan)](https://github.com/crate/devrel-shipping-forecast-geo-demo)
 ```
 :::
 


### PR DESCRIPTION
## About
It adds the new MicroPython client to the list of clients that use the HTTP API.

## Preview
https://crate-clients-tools--145.org.readthedocs.build/en/145/connect/index.html#http
