### PR TITLE
Connect: Fix and improve connection strings

### DIFF
--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -59,10 +59,10 @@ applications and drivers may obtain connection properties in different formats.
 **Connection-string examples**
 
 A native PostgreSQL connection string.
-`postgresql://<username>@<clustername>.cratedb.net/crate`
+`postgresql://<username>@<clustername>.cratedb.net/`
 
 A connection string for SQLAlchemy or Apache Flink.
-`crate://<username>@<clustername>.cratedb.net/crate?ssl=true`
+`crate://<username>@<clustername>.cratedb.net/?ssl=true`
 
 An HTTP URL to visit Admin UI.
 `https://<username>@<clustername>.cratedb.net:4200/`
@@ -101,10 +101,10 @@ An HTTP URL to visit Admin UI.
 **Connection-string examples**
 
 A native PostgreSQL connection string.
-`postgresql://crate@localhost:5432/crate`
+`postgresql://crate@localhost:5432/`
 
 A connection string for SQLAlchemy or Apache Flink.
-`crate://crate@localhost/crate`
+`crate://crate@localhost/`
 
 An HTTP URL to visit Admin UI.
 `http://crate@localhost:4200/`

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -62,7 +62,7 @@ A native PostgreSQL connection string.
 `postgresql://<username>@<clustername>.cratedb.net/crate`
 
 A connection string for SQLAlchemy or Apache Flink.
-`crate://<username>@<clustername>.cratedb.net/crate`
+`crate://<username>@<clustername>.cratedb.net/crate?ssl=true`
 
 An HTTP URL to visit Admin UI.
 `https://<username>@<clustername>.cratedb.net:4200/`

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -59,13 +59,13 @@ applications and drivers may obtain connection properties in different formats.
 **Connection-string examples**
 
 A native PostgreSQL connection string.
-`postgresql://<username>@<clustername>.cratedb.net/`
+`postgresql://<username>:<password>@<clustername>.cratedb.net/`
 
 A connection string for SQLAlchemy or Apache Flink.
-`crate://<username>@<clustername>.cratedb.net/?ssl=true`
+`crate://<username>:<password>@<clustername>.cratedb.net/?ssl=true`
 
 An HTTP URL to visit Admin UI.
-`https://<username>@<clustername>.cratedb.net:4200/`
+`https://<username>:<password>@<clustername>.cratedb.net:4200/`
 
 :::
 

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -30,9 +30,15 @@ configured with corresponding connection properties. Please note that different
 applications and drivers may obtain connection properties in different formats.
 
 <style>
-/* Verbatim inline code needs to be smaller to fit into their containers. */
-code span.pre {
-  font-size: smaller;
+/* Code blocks need to be slimmer */
+.driver-slim div.highlight-default {
+  margin-top: 0.2em;
+}
+.driver-slim pre {
+  padding: 0.4em;
+}
+.driver-slim p {
+  margin-bottom: 0;
 }
 </style>
 
@@ -51,9 +57,9 @@ code span.pre {
 
 **Connection properties**
 
-:Host: `<clustername>`.cratedb.net
+:Host: `<cluster>`.cratedb.net
 :Port: 5432 (PostgreSQL) or<br>4200 (HTTP)
-:User: `<username>`
+:User: `<user>`
 :Pass: `<password>`
 
 :::
@@ -62,24 +68,35 @@ code span.pre {
 :columns: 8
 :margin: 0
 :padding: 0
+:class: driver-slim
 
 **Connection-string examples**
+<br><br>
 
-A native PostgreSQL connection string, e.g. for `psql`.
-<br>
-`postgresql://<username>:<password>@<clustername>.cratedb.net:5432/crate`
+**Native PostgreSQL, psql**
+```
+postgresql://<user>:<password>@<cluster>.cratedb.net:5432/doc
+```
 
-A connection string for the CrateDB JDBC Driver, e.g. for Apache Flink.
-<br>
-`jdbc:crate://<username>:<password>@<clustername>.cratedb.net:5432/`
+**JDBC: PostgreSQL pgJDBC**
+```
+jdbc:postgresql://<user>:<password>@<cluster>.cratedb.net:5432/doc
+```
 
-A connection string for SQLAlchemy.
-<br>
-`crate://<username>:<password>@<clustername>.cratedb.net:4200/?ssl=true`
+**JDBC: CrateDB JDBC, e.g. Apache Flink**
+```
+jdbc:crate://<user>:<password>@<cluster>.cratedb.net:5432/doc
+```
 
-An HTTP URL to visit Admin UI, or use with `crash`.
-<br>
-`https://<username>:<password>@<clustername>.cratedb.net:4200/`
+**HTTP: Admin UI, CLI, CrateDB drivers**
+```
+https://<user>:<password>@<cluster>.cratedb.net:4200/
+```
+
+**SQLAlchemy**
+```
+crate://<user>:<password>@<cluster>.cratedb.net:4200/?schema=doc&ssl=true
+```
 
 :::
 
@@ -111,24 +128,35 @@ An HTTP URL to visit Admin UI, or use with `crash`.
 :columns: 8
 :margin: 0
 :padding: 0
+:class: driver-slim
 
 **Connection-string examples**
+<br><br>
 
-A native PostgreSQL connection string, e.g. for `psql`.
-<br>
-`postgresql://crate@localhost:5432/crate`
+**Native PostgreSQL, psql**
+```
+postgresql://crate@localhost:5432/doc
+```
 
-A connection string for the CrateDB JDBC Driver, e.g. for Apache Flink.
-<br>
-`jdbc:crate://crate@localhost:5432/`
+**JDBC: PostgreSQL pgJDBC**
+```
+jdbc:crate://crate@localhost:5432/doc
+```
 
-A connection string for SQLAlchemy.
-<br>
-`crate://crate@localhost:4200/`
+**JDBC: CrateDB JDBC, e.g. Apache Flink**
+```
+jdbc:crate://<user>:<password>@localhost:5432/doc
+```
 
-An HTTP URL to visit Admin UI, or use with `crash`.
-<br>
-`http://crate@localhost:4200/`
+**HTTP: Admin UI, CLI, CrateDB drivers**
+```
+http://crate@localhost:4200/
+```
+
+**SQLAlchemy**
+```
+crate://crate@localhost:4200/?schema=doc
+```
 
 :::
 

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -167,11 +167,17 @@ crate://crate@localhost:4200/?schema=doc
 
 
 ```{tip}
-- Specify the [schema] name `doc`, if you are asked for a *database name*.
-- The default [superuser] on a vanilla CrateDB cluster is called `crate`,
-  without a password.
-- When aiming to authenticate properly, please learn about the available
-  [authentication] options. 
+- CrateDB's fixed catalog name is `crate`, the default schema name is `doc`.
+- CrateDB does not implement the notion of a database,
+  however tables can be created in different [schemas].
+- When asked for a *database name*, specifying a schema name (any),
+  or the fixed catalog name `crate` may be applicable.
+- If a database-/schema-name is omitted while connecting,
+  the PostgreSQL drivers may default to the "username".
+- The predefined [superuser] on an unconfigured CrateDB cluster is
+  called `crate`, defined without a password.
+- For authenticating properly, please learn about the available
+  [authentication] options.
 ```
 
 
@@ -562,4 +568,5 @@ ruby
 [python-dbapi-by-example]: inv:crate-python:*:label#by-example
 [python-sqlalchemy-by-example]: inv:sqlalchemy-cratedb:*:label#by-example
 [schema]: inv:crate-reference:*:label#ddl-create-table-schemas
+[schemas]: inv:crate-reference:*:label#ddl-create-table-schemas
 [superuser]: inv:crate-reference:*:label#administration_user_management

--- a/docs/connect/index.md
+++ b/docs/connect/index.md
@@ -29,6 +29,13 @@ In order to connect to CrateDB, your application or driver needs to be
 configured with corresponding connection properties. Please note that different
 applications and drivers may obtain connection properties in different formats.
 
+<style>
+/* Verbatim inline code needs to be smaller to fit into their containers. */
+code span.pre {
+  font-size: smaller;
+}
+</style>
+
 ::::::{tab-set}
 
 :::::{tab-item} CrateDB and CrateDB Cloud
@@ -38,33 +45,40 @@ applications and drivers may obtain connection properties in different formats.
 :padding: 0
 
 :::{grid-item}
-:columns: 5
+:columns: 4
 :margin: 0
 :padding: 0
 
 **Connection properties**
 
 :Host: `<clustername>`.cratedb.net
-:Port: 5432 (PostgreSQL) or 4200 (HTTP)
+:Port: 5432 (PostgreSQL) or<br>4200 (HTTP)
 :User: `<username>`
 :Pass: `<password>`
 
 :::
 
 :::{grid-item}
-:columns: 7
+:columns: 8
 :margin: 0
 :padding: 0
 
 **Connection-string examples**
 
-A native PostgreSQL connection string.
-`postgresql://<username>:<password>@<clustername>.cratedb.net/`
+A native PostgreSQL connection string, e.g. for `psql`.
+<br>
+`postgresql://<username>:<password>@<clustername>.cratedb.net:5432/crate`
 
-A connection string for SQLAlchemy or Apache Flink.
-`crate://<username>:<password>@<clustername>.cratedb.net/?ssl=true`
+A connection string for the CrateDB JDBC Driver, e.g. for Apache Flink.
+<br>
+`jdbc:crate://<username>:<password>@<clustername>.cratedb.net:5432/`
 
-An HTTP URL to visit Admin UI.
+A connection string for SQLAlchemy.
+<br>
+`crate://<username>:<password>@<clustername>.cratedb.net:4200/?ssl=true`
+
+An HTTP URL to visit Admin UI, or use with `crash`.
+<br>
 `https://<username>:<password>@<clustername>.cratedb.net:4200/`
 
 :::
@@ -80,33 +94,40 @@ An HTTP URL to visit Admin UI.
 :padding: 0
 
 :::{grid-item}
-:columns: 5
+:columns: 4
 :margin: 0
 :padding: 0
 
 **Connection properties**
 
 :Host: localhost
-:Port: 5432 (PostgreSQL) or 4200 (HTTP)
+:Port: 5432 (PostgreSQL) or<br>4200 (HTTP)
 :User: `crate`
 :Pass: (empty)
 
 :::
 
 :::{grid-item}
-:columns: 7
+:columns: 8
 :margin: 0
 :padding: 0
 
 **Connection-string examples**
 
-A native PostgreSQL connection string.
-`postgresql://crate@localhost:5432/`
+A native PostgreSQL connection string, e.g. for `psql`.
+<br>
+`postgresql://crate@localhost:5432/crate`
 
-A connection string for SQLAlchemy or Apache Flink.
-`crate://crate@localhost/`
+A connection string for the CrateDB JDBC Driver, e.g. for Apache Flink.
+<br>
+`jdbc:crate://crate@localhost:5432/`
 
-An HTTP URL to visit Admin UI.
+A connection string for SQLAlchemy.
+<br>
+`crate://crate@localhost:4200/`
+
+An HTTP URL to visit Admin UI, or use with `crash`.
+<br>
 `http://crate@localhost:4200/`
 
 :::


### PR DESCRIPTION
## About
A few fixes/improvements to different connection strings we are presenting on the documentation. For example:
- Add missing `ssl=true` argument on SQLAlchemy connection string.
- Remove `/<dbname>` argument from SQLAlchemy connection string, because it would cause errors.

## Preview
https://crate-clients-tools--151.org.readthedocs.build/en/151/connect/

/cc @surister, @simonprickett 