### PR TITLE
Build Status: Add GHA workflow item that publishes cratedb-datasets

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -140,6 +140,12 @@ on behalf of [cratedb-examples] and [academy-fundamentals-course].
 <a href="https://github.com/crate/cratedb-examples/actions/workflows/timeseries.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-examples/timeseries.yml?branch=main&label=Time%20Series" loading="lazy"></a>
 </div>
+<div>
+<b>Datasets</b>
+<br>
+<a href="https://github.com/crate/cratedb-datasets/actions/workflows/publish.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-datasets/publish.yml?branch=main&label=Datasets" loading="lazy"></a>
+</div>
 </td>
 </tr>
 


### PR DESCRIPTION
## About
A new item on the [Build Status](https://crate-clients-tools--216.org.readthedocs.build/en/216/status.html) page, that relays the status of [a new CI job](https://github.com/crate/cratedb-datasets/pull/21) into an overview page.

## References
- https://github.com/crate/infrastructure/pull/3259
- https://github.com/crate/cratedb-datasets/pull/21
