### PR TITLE
Send build status to Slack

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -1,0 +1,43 @@
+name: build-status
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4 
+
+      - name: Checkout cratedb-github-summary
+        uses: actions/checkout@v4
+        with:
+          repository: crate/cratedb-github-summary
+          path: cratedb-github-summary
+          ref: main
+          token: ${{ github.token }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build report
+        run: |
+          # Login to gh so script can call it
+          echo "${{ github.token }}" | gh auth login --with-token
+          # Generate the report
+          REPORT=$(uv run https://github.com/tech-writing/rapporto/raw/refs/heads/main/rapporto.py -- qa --repositories-file=cratedb-github-summary/cratedb-repositories-ecosystem.txt)
+          echo "report=$REPORT" >> "$GITHUB_OUTPUT"
+
+      - name: Send report data to the Slack workflow 
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACKURL_BUILD_STATUS }}
+          webhook-type: webhook-trigger
+          payload: |
+            report: ${{ github.event.report }}

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -33,7 +33,7 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           # Generate the report
           echo "REPORT<<EOF" >> $GITHUB_ENV
-          uv run https://github.com/tech-writing/rapporto/raw/refs/heads/main/rapporto.py -- qa --repositories-file=cratedb-github-summary/cratedb-repositories-ecosystem.txt>> $GITHUB_ENV
+          uv run https://github.com/tech-writing/rapporto/raw/refs/tags/v0.0.2/rapporto.py -- qa --repositories-file=cratedb-github-summary/cratedb-repositories-ecosystem.txt>> $GITHUB_ENV
           echo "EOF" >> "$GITHUB_ENV"
 
       - name: Send report data to the Slack workflow

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -2,7 +2,7 @@ name: build-status
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v4
 
       - name: Checkout cratedb-github-summary
         uses: actions/checkout@v4
@@ -21,23 +21,28 @@ jobs:
           repository: crate/cratedb-github-summary
           path: cratedb-github-summary
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
       - name: Build report
+        id: build-report
         run: |
           # Login to gh so script can call it
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           # Generate the report
-          REPORT=$(uv run https://github.com/tech-writing/rapporto/raw/refs/heads/main/rapporto.py -- qa --repositories-file=cratedb-github-summary/cratedb-repositories-ecosystem.txt)
-          echo "report=$REPORT" >> "$GITHUB_OUTPUT"
+          echo "REPORT<<EOF" >> $GITHUB_ENV
+          uv run https://github.com/tech-writing/rapporto/raw/refs/heads/main/rapporto.py -- qa --repositories-file=cratedb-github-summary/cratedb-repositories-ecosystem.txt>> $GITHUB_ENV
+          echo "EOF" >> "$GITHUB_ENV"
 
-      - name: Send report data to the Slack workflow 
-        uses: slackapi/slack-github-action@v2
+      - name: Send report data to the Slack workflow
+        uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACKURL_BUILD_STATUS }}
-          webhook-type: webhook-trigger
+          webhook-type: incoming-webhook
           payload: |
-            report: ${{ github.event.report }}
+            report: 
+              type: "mrdwn"
+              text: "${{ env.REPORT }}"
+

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -21,7 +21,7 @@ jobs:
           repository: crate/cratedb-github-summary
           path: cratedb-github-summary
           ref: main
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -29,7 +29,7 @@ jobs:
       - name: Build report
         run: |
           # Login to gh so script can call it
-          echo "${{ github.token }}" | gh auth login --with-token
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           # Generate the report
           REPORT=$(uv run https://github.com/tech-writing/rapporto/raw/refs/heads/main/rapporto.py -- qa --repositories-file=cratedb-github-summary/cratedb-repositories-ecosystem.txt)
           echo "report=$REPORT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Pull report about build status and send it to Slack

Partially tested manually - see https://github.com/crate/kneth_playground/actions/runs/13328718084

## Todo

 - [ ] Add secret `SLACKURL_BUILD_STATUS` to repository
 - [ ] Add GitHub token (`GH_PAT` is the workflow)
 - [ ] Create a proper Slack webhook and decide which channel to post in

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #148 
