### PR TITLE
Build Status: Add badge/shield about Tableau

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -182,6 +182,8 @@ to CrateDB.
     <img src="https://img.shields.io/github/actions/workflow/status/crate/langchain-cratedb/ci.yml?branch=main&label=LangChain" loading="lazy"></a>
 <a href="https://github.com/crate/mlflow-cratedb/actions/workflows/main.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/crate/mlflow-cratedb/main.yml?branch=main&label=MLflow" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-tableau-connector/actions/workflows/main.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-tableau-connector/main.yml?branch=main&label=Tableau" loading="lazy"></a>
 </td>
 </tr>
 


### PR DESCRIPTION
## About
The new Tableau connector significantly gained maturity, now at >95% test cases succeeding, and dearly needs a representation on the [Build Status](https://cratedb.com/docs/crate/clients-tools/en/latest/status.html) page.

## Preview
https://crate-clients-tools--229.org.readthedocs.build/en/229/status.html#applications-connectors-sdks

## References
- https://github.com/crate/cratedb-tableau-connector/pull/33