### PR TITLE
Build Status: Add badge/shield about Fivetran

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -180,6 +180,8 @@ to CrateDB.
     <img src="https://img.shields.io/github/actions/workflow/status/crate/dbt-cratedb2/integration-tests.yml?branch=main&label=dbt" loading="lazy"></a>
 <a href="https://github.com/crate/cratedb-estuary">
     <img src="https://img.shields.io/badge/Estuary-passing-success" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-fivetran-destination/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/crate/cratedb-fivetran-destination/tests.yml?branch=main&label=Fivetran" loading="lazy"></a>
 <a href="https://github.com/crate/langchain-cratedb/actions/workflows/ci.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/crate/langchain-cratedb/ci.yml?branch=main&label=LangChain" loading="lazy"></a>
 <a href="https://github.com/crate/mlflow-cratedb/actions/workflows/main.yml">


### PR DESCRIPTION
## About
The new Fivetran connector is in its infancy, but clocking in with ~75% feature coverage, it may also have a representation on the [Build Status](https://cratedb.com/docs/crate/clients-tools/en/latest/status.html) page right away.

## Preview
https://crate-clients-tools--231.org.readthedocs.build/en/231/status.html#applications-connectors-sdks

## References
- https://github.com/crate-workbench/cratedb-fivetran-destination/pull/4
